### PR TITLE
Bugfix/rhoaieng 42316 stuck finalizer on shutdown

### DIFF
--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -17,10 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"net/http"
 	"os"
+	"time"
 
 	zaplog "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -135,25 +137,63 @@ func main() {
 		setupLog.Error(err, "Could not initialize runtimes")
 		os.Exit(1)
 	}
+
+	// Channel to receive reconcilers from setupControllers goroutine
+	reconcilersCh := make(chan *controller.Reconcilers, 1)
+
 	// Set up controllers using goroutines to start the manager quickly.
-	go setupControllers(mgr, runtimes, certsReady)
+	go setupControllers(mgr, runtimes, certsReady, reconcilersCh)
 
 	setupLog.Info("Starting manager")
 	if err = mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "Could not run manager")
 		os.Exit(1)
 	}
+
+	// Perform graceful shutdown: remove finalizers from terminating resources
+	// This prevents resources from being stuck in Terminating state when the operator exits
+	// Fix for RHOAIENG-42316: Stuck Trainer CR when disabling Trainer component
+	select {
+	case reconcilers := <-reconcilersCh:
+		if reconcilers != nil {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			setupLog.Info("Performing graceful shutdown")
+
+			if reconcilers.ClusterTrainingRuntime != nil {
+				if err := reconcilers.ClusterTrainingRuntime.GracefulShutdown(shutdownCtx); err != nil {
+					setupLog.Error(err, "Error during ClusterTrainingRuntime graceful shutdown")
+				}
+			}
+
+			if reconcilers.TrainingRuntime != nil {
+				if err := reconcilers.TrainingRuntime.GracefulShutdown(shutdownCtx); err != nil {
+					setupLog.Error(err, "Error during TrainingRuntime graceful shutdown")
+				}
+			}
+
+			setupLog.Info("Graceful shutdown completed")
+		}
+	default:
+		setupLog.Info("Reconcilers not available for graceful shutdown")
+	}
 }
 
-func setupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, certsReady <-chan struct{}) {
+func setupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, certsReady <-chan struct{}, reconcilersCh chan<- *controller.Reconcilers) {
 	setupLog.Info("Waiting for certificate generation to complete")
 	<-certsReady
 	setupLog.Info("Certs ready")
 
-	if failedCtrlName, err := controller.SetupControllers(mgr, runtimes, ctrlpkg.Options{}); err != nil {
+	failedCtrlName, reconcilers, err := controller.SetupControllers(mgr, runtimes, ctrlpkg.Options{})
+	if err != nil {
 		setupLog.Error(err, "Could not create controller", "controller", failedCtrlName)
 		os.Exit(1)
 	}
+
+	// Send reconcilers to main for graceful shutdown handling
+	reconcilersCh <- reconcilers
+
 	if failedWebhook, err := webhooks.Setup(mgr, runtimes); err != nil {
 		setupLog.Error(err, "Could not create webhook", "webhook", failedWebhook)
 		os.Exit(1)

--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -17,12 +17,10 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"net/http"
 	"os"
-	"time"
 
 	zaplog "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -138,61 +136,26 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Channel to receive reconcilers from setupControllers goroutine
-	reconcilersCh := make(chan *controller.Reconcilers, 1)
-
 	// Set up controllers using goroutines to start the manager quickly.
-	go setupControllers(mgr, runtimes, certsReady, reconcilersCh)
+	go setupControllers(mgr, runtimes, certsReady)
 
 	setupLog.Info("Starting manager")
 	if err = mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "Could not run manager")
 		os.Exit(1)
 	}
-
-	// Perform graceful shutdown: remove finalizers from terminating resources
-	// This prevents resources from being stuck in Terminating state when the operator exits
-	// Fix for RHOAIENG-42316: Stuck Trainer CR when disabling Trainer component
-	select {
-	case reconcilers := <-reconcilersCh:
-		if reconcilers != nil {
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			setupLog.Info("Performing graceful shutdown")
-
-			if reconcilers.ClusterTrainingRuntime != nil {
-				if err := reconcilers.ClusterTrainingRuntime.GracefulShutdown(shutdownCtx); err != nil {
-					setupLog.Error(err, "Error during ClusterTrainingRuntime graceful shutdown")
-				}
-			}
-
-			if reconcilers.TrainingRuntime != nil {
-				if err := reconcilers.TrainingRuntime.GracefulShutdown(shutdownCtx); err != nil {
-					setupLog.Error(err, "Error during TrainingRuntime graceful shutdown")
-				}
-			}
-
-			setupLog.Info("Graceful shutdown completed")
-		}
-	default:
-		setupLog.Info("Reconcilers not available for graceful shutdown")
-	}
 }
 
-func setupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, certsReady <-chan struct{}, reconcilersCh chan<- *controller.Reconcilers) {
+func setupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, certsReady <-chan struct{}) {
 	setupLog.Info("Waiting for certificate generation to complete")
 	<-certsReady
 	setupLog.Info("Certs ready")
 
-	failedCtrlName, reconcilers, err := controller.SetupControllers(mgr, runtimes, ctrlpkg.Options{})
+	failedCtrlName, _, err := controller.SetupControllers(mgr, runtimes, ctrlpkg.Options{})
 	if err != nil {
 		setupLog.Error(err, "Could not create controller", "controller", failedCtrlName)
 		os.Exit(1)
 	}
-
-	// Send reconcilers to main for graceful shutdown handling
-	reconcilersCh <- reconcilers
 
 	if failedWebhook, err := webhooks.Setup(mgr, runtimes); err != nil {
 		setupLog.Error(err, "Could not create webhook", "webhook", failedWebhook)

--- a/pkg/controller/clustertrainingruntime_controller.go
+++ b/pkg/controller/clustertrainingruntime_controller.go
@@ -122,7 +122,7 @@ func (r *ClusterTrainingRuntimeReconciler) GracefulShutdown(ctx context.Context)
 		log.Info("Removing finalizer from terminating ClusterTrainingRuntime",
 			"name", clRuntime.Name)
 
-		// Remove the finalizer to allow deletion
+		// Remove the finalizer using the standard controller-runtime API
 		ctrlutil.RemoveFinalizer(clRuntime, constants.ResourceInUseFinalizer)
 		if err := r.client.Update(ctx, clRuntime); err != nil {
 			log.Error(err, "Failed to remove finalizer during graceful shutdown",

--- a/pkg/controller/clustertrainingruntime_controller.go
+++ b/pkg/controller/clustertrainingruntime_controller.go
@@ -90,6 +90,55 @@ func (r *ClusterTrainingRuntimeReconciler) Reconcile(ctx context.Context, reques
 	return ctrl.Result{}, nil
 }
 
+// GracefulShutdown removes finalizers from ClusterTrainingRuntimes during operator shutdown.
+// This prevents resources from being stuck in Terminating state when the operator is terminated
+// before it can complete normal finalizer cleanup.
+// Fix for RHOAIENG-42316: Stuck Trainer CR when disabling Trainer component.
+func (r *ClusterTrainingRuntimeReconciler) GracefulShutdown(ctx context.Context) error {
+	log := r.log.WithName("graceful-shutdown")
+	log.Info("Starting graceful shutdown for ClusterTrainingRuntimes")
+
+	// List all ClusterTrainingRuntimes
+	var clRuntimeList trainer.ClusterTrainingRuntimeList
+	if err := r.client.List(ctx, &clRuntimeList); err != nil {
+		log.Error(err, "Failed to list ClusterTrainingRuntimes during graceful shutdown")
+		return err
+	}
+
+	// Process ClusterTrainingRuntimes that are being deleted
+	for i := range clRuntimeList.Items {
+		clRuntime := &clRuntimeList.Items[i]
+
+		// Skip if not being deleted
+		if clRuntime.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		// Skip if finalizer not present
+		if !ctrlutil.ContainsFinalizer(clRuntime, constants.ResourceInUseFinalizer) {
+			continue
+		}
+
+		log.Info("Removing finalizer from terminating ClusterTrainingRuntime",
+			"name", clRuntime.Name)
+
+		// Remove the finalizer to allow deletion
+		ctrlutil.RemoveFinalizer(clRuntime, constants.ResourceInUseFinalizer)
+		if err := r.client.Update(ctx, clRuntime); err != nil {
+			log.Error(err, "Failed to remove finalizer during graceful shutdown",
+				"name", clRuntime.Name)
+			// Continue processing others even if one fails
+			continue
+		}
+
+		log.Info("Successfully removed finalizer during graceful shutdown",
+			"name", clRuntime.Name)
+	}
+
+	log.Info("Graceful shutdown completed for ClusterTrainingRuntimes")
+	return nil
+}
+
 func (r *ClusterTrainingRuntimeReconciler) NotifyTrainJobUpdate(oldJob, newJob *trainer.TrainJob) {
 	var clRuntimeNSName *types.NamespacedName
 	switch {

--- a/pkg/controller/clustertrainingruntime_controller_test.go
+++ b/pkg/controller/clustertrainingruntime_controller_test.go
@@ -222,3 +222,110 @@ func TestNotifyTrainJobUpdate_ClusterTrainingRuntimeReconciler(t *testing.T) {
 		})
 	}
 }
+
+// TestGracefulShutdown_ClusterTrainingRuntimeReconciler tests the graceful shutdown behavior
+// for RHOAIENG-42316: Stuck Trainer CR when disabling Trainer component
+func TestGracefulShutdown_ClusterTrainingRuntimeReconciler(t *testing.T) {
+	cases := map[string]struct {
+		clRuntimes              []trainer.ClusterTrainingRuntime
+		wantRemainingFinalizers map[string][]string // runtime name -> finalizers
+		wantDeleted             []string            // runtime names that should be deleted
+	}{
+		"removes finalizer from terminating ClusterTrainingRuntime": {
+			clRuntimes: []trainer.ClusterTrainingRuntime{
+				*utiltesting.MakeClusterTrainingRuntimeWrapper("runtime-terminating").
+					Finalizers(constants.ResourceInUseFinalizer).
+					DeletionTimestamp(metav1.Now()).
+					Obj(),
+			},
+			wantDeleted: []string{"runtime-terminating"}, // Deleted after finalizer removed
+		},
+		"keeps finalizer on non-terminating ClusterTrainingRuntime": {
+			clRuntimes: []trainer.ClusterTrainingRuntime{
+				*utiltesting.MakeClusterTrainingRuntimeWrapper("runtime-active").
+					Finalizers(constants.ResourceInUseFinalizer).
+					Obj(),
+			},
+			wantRemainingFinalizers: map[string][]string{
+				"runtime-active": {constants.ResourceInUseFinalizer}, // Finalizer should remain
+			},
+		},
+		"handles multiple runtimes with mixed states": {
+			clRuntimes: []trainer.ClusterTrainingRuntime{
+				*utiltesting.MakeClusterTrainingRuntimeWrapper("runtime-terminating-1").
+					Finalizers(constants.ResourceInUseFinalizer).
+					DeletionTimestamp(metav1.Now()).
+					Obj(),
+				*utiltesting.MakeClusterTrainingRuntimeWrapper("runtime-active").
+					Finalizers(constants.ResourceInUseFinalizer).
+					Obj(),
+				*utiltesting.MakeClusterTrainingRuntimeWrapper("runtime-terminating-2").
+					Finalizers(constants.ResourceInUseFinalizer, "another-finalizer").
+					DeletionTimestamp(metav1.Now()).
+					Obj(),
+			},
+			wantDeleted: []string{"runtime-terminating-1"}, // Deleted after last finalizer removed
+			wantRemainingFinalizers: map[string][]string{
+				"runtime-active":        {constants.ResourceInUseFinalizer}, // Kept (not terminating)
+				"runtime-terminating-2": {"another-finalizer"},              // Only ResourceInUseFinalizer removed
+			},
+		},
+		"does not fail on runtime without finalizer": {
+			clRuntimes: []trainer.ClusterTrainingRuntime{
+				*utiltesting.MakeClusterTrainingRuntimeWrapper("runtime-active-no-finalizer").
+					Obj(),
+			},
+			wantRemainingFinalizers: map[string][]string{
+				"runtime-active-no-finalizer": nil, // No finalizer to remove, not terminating
+			},
+		},
+		"handles empty list": {
+			clRuntimes:              []trainer.ClusterTrainingRuntime{},
+			wantRemainingFinalizers: map[string][]string{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Build client with test resources
+			builder := utiltesting.NewClientBuilder()
+			for i := range tc.clRuntimes {
+				builder = builder.WithObjects(&tc.clRuntimes[i])
+			}
+			cli := builder.Build()
+
+			r := NewClusterTrainingRuntimeReconciler(cli, nil)
+
+			// Call GracefulShutdown
+			err := r.GracefulShutdown(ctx)
+			if err != nil {
+				t.Errorf("GracefulShutdown returned unexpected error: %v", err)
+			}
+
+			// Verify resources that should be deleted
+			for _, runtimeName := range tc.wantDeleted {
+				var gotRuntime trainer.ClusterTrainingRuntime
+				err := cli.Get(ctx, client.ObjectKey{Name: runtimeName}, &gotRuntime)
+				if err == nil {
+					t.Errorf("Expected ClusterTrainingRuntime %s to be deleted, but it still exists", runtimeName)
+				}
+			}
+
+			// Verify finalizers on resources that should remain
+			for runtimeName, wantFinalizers := range tc.wantRemainingFinalizers {
+				var gotRuntime trainer.ClusterTrainingRuntime
+				err := cli.Get(ctx, client.ObjectKey{Name: runtimeName}, &gotRuntime)
+				if err != nil {
+					t.Errorf("Failed to get ClusterTrainingRuntime %s: %v", runtimeName, err)
+					continue
+				}
+
+				if diff := cmp.Diff(wantFinalizers, gotRuntime.Finalizers); len(diff) != 0 {
+					t.Errorf("Unexpected finalizers for %s (-want, +got):\n%s", runtimeName, diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -24,20 +24,26 @@ import (
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 )
 
-func SetupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, options controller.Options) (string, error) {
+// Reconcilers holds reconciler instances for graceful shutdown handling.
+type Reconcilers struct {
+	TrainingRuntime        *TrainingRuntimeReconciler
+	ClusterTrainingRuntime *ClusterTrainingRuntimeReconciler
+}
+
+func SetupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, options controller.Options) (string, *Reconcilers, error) {
 	runtimeRec := NewTrainingRuntimeReconciler(
 		mgr.GetClient(),
 		mgr.GetEventRecorderFor("trainer-trainingruntime-controller"),
 	)
 	if err := runtimeRec.SetupWithManager(mgr, options); err != nil {
-		return trainer.TrainingRuntimeKind, err
+		return trainer.TrainingRuntimeKind, nil, err
 	}
 	clRuntimeRec := NewClusterTrainingRuntimeReconciler(
 		mgr.GetClient(),
 		mgr.GetEventRecorderFor("trainer-clustertrainingruntime-controller"),
 	)
 	if err := clRuntimeRec.SetupWithManager(mgr, options); err != nil {
-		return trainer.ClusterTrainingRuntimeKind, err
+		return trainer.ClusterTrainingRuntimeKind, nil, err
 	}
 	if err := NewTrainJobReconciler(
 		mgr.GetClient(),
@@ -46,7 +52,13 @@ func SetupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, opt
 		runtimes,
 		WithWatchers(runtimeRec, clRuntimeRec),
 	).SetupWithManager(mgr, options); err != nil {
-		return trainer.TrainJobKind, err
+		return trainer.TrainJobKind, nil, err
 	}
-	return "", nil
+
+	// Return reconciler instances for graceful shutdown handling
+	reconcilers := &Reconcilers{
+		TrainingRuntime:        runtimeRec,
+		ClusterTrainingRuntime: clRuntimeRec,
+	}
+	return "", reconcilers, nil
 }

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -17,6 +17,10 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
@@ -28,6 +32,43 @@ import (
 type Reconcilers struct {
 	TrainingRuntime        *TrainingRuntimeReconciler
 	ClusterTrainingRuntime *ClusterTrainingRuntimeReconciler
+}
+
+// GracefulShutdownRunnable implements the controller-runtime Runnable interface
+// to perform graceful shutdown when the manager's context is cancelled.
+type GracefulShutdownRunnable struct {
+	ClusterTrainingRuntime *ClusterTrainingRuntimeReconciler
+	TrainingRuntime        *TrainingRuntimeReconciler
+	log                    logr.Logger
+}
+
+// Start blocks until the context is cancelled (SIGTERM received), then performs graceful shutdown.
+// This is called by the controller-runtime manager and provides a window where the webhook
+// server is still draining but the context is cancelled, allowing client.Update() to succeed.
+func (r *GracefulShutdownRunnable) Start(ctx context.Context) error {
+	// Block until context is cancelled (SIGTERM received)
+	<-ctx.Done()
+
+	r.log.Info("Performing graceful shutdown")
+
+	// Create new context with timeout for cleanup operations
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if r.ClusterTrainingRuntime != nil {
+		if err := r.ClusterTrainingRuntime.GracefulShutdown(shutdownCtx); err != nil {
+			r.log.Error(err, "Error during ClusterTrainingRuntime graceful shutdown")
+		}
+	}
+
+	if r.TrainingRuntime != nil {
+		if err := r.TrainingRuntime.GracefulShutdown(shutdownCtx); err != nil {
+			r.log.Error(err, "Error during TrainingRuntime graceful shutdown")
+		}
+	}
+
+	r.log.Info("Graceful shutdown completed")
+	return nil
 }
 
 func SetupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, options controller.Options) (string, *Reconcilers, error) {
@@ -55,7 +96,19 @@ func SetupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, opt
 		return trainer.TrainJobKind, nil, err
 	}
 
-	// Return reconciler instances for graceful shutdown handling
+	// Register the graceful shutdown runnable
+	// This will be called when the manager's context is cancelled (SIGTERM),
+	// providing a window where the webhook server is still draining but client.Update() can succeed
+	shutdownRunnable := &GracefulShutdownRunnable{
+		ClusterTrainingRuntime: clRuntimeRec,
+		TrainingRuntime:        runtimeRec,
+		log:                    ctrl.Log.WithName("graceful-shutdown"),
+	}
+	if err := mgr.Add(shutdownRunnable); err != nil {
+		return "graceful-shutdown-runnable", nil, err
+	}
+
+	// Return reconciler instances for backward compatibility
 	reconcilers := &Reconcilers{
 		TrainingRuntime:        runtimeRec,
 		ClusterTrainingRuntime: clRuntimeRec,

--- a/pkg/controller/trainingruntime_controller.go
+++ b/pkg/controller/trainingruntime_controller.go
@@ -126,7 +126,7 @@ func (r *TrainingRuntimeReconciler) GracefulShutdown(ctx context.Context) error 
 		log.Info("Removing finalizer from terminating TrainingRuntime",
 			"namespace", runtime.Namespace, "name", runtime.Name)
 
-		// Remove the finalizer to allow deletion
+		// Remove the finalizer using the standard controller-runtime API
 		ctrlutil.RemoveFinalizer(runtime, constants.ResourceInUseFinalizer)
 		if err := r.client.Update(ctx, runtime); err != nil {
 			log.Error(err, "Failed to remove finalizer during graceful shutdown",

--- a/pkg/controller/trainingruntime_controller.go
+++ b/pkg/controller/trainingruntime_controller.go
@@ -94,6 +94,55 @@ func (r *TrainingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{}, nil
 }
 
+// GracefulShutdown removes finalizers from TrainingRuntimes during operator shutdown.
+// This prevents resources from being stuck in Terminating state when the operator is terminated
+// before it can complete normal finalizer cleanup.
+// Fix for RHOAIENG-42316: Stuck Trainer CR when disabling Trainer component.
+func (r *TrainingRuntimeReconciler) GracefulShutdown(ctx context.Context) error {
+	log := r.log.WithName("graceful-shutdown")
+	log.Info("Starting graceful shutdown for TrainingRuntimes")
+
+	// List all TrainingRuntimes across all namespaces
+	var runtimeList trainer.TrainingRuntimeList
+	if err := r.client.List(ctx, &runtimeList); err != nil {
+		log.Error(err, "Failed to list TrainingRuntimes during graceful shutdown")
+		return err
+	}
+
+	// Process TrainingRuntimes that are being deleted
+	for i := range runtimeList.Items {
+		runtime := &runtimeList.Items[i]
+
+		// Skip if not being deleted
+		if runtime.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		// Skip if finalizer not present
+		if !ctrlutil.ContainsFinalizer(runtime, constants.ResourceInUseFinalizer) {
+			continue
+		}
+
+		log.Info("Removing finalizer from terminating TrainingRuntime",
+			"namespace", runtime.Namespace, "name", runtime.Name)
+
+		// Remove the finalizer to allow deletion
+		ctrlutil.RemoveFinalizer(runtime, constants.ResourceInUseFinalizer)
+		if err := r.client.Update(ctx, runtime); err != nil {
+			log.Error(err, "Failed to remove finalizer during graceful shutdown",
+				"namespace", runtime.Namespace, "name", runtime.Name)
+			// Continue processing others even if one fails
+			continue
+		}
+
+		log.Info("Successfully removed finalizer during graceful shutdown",
+			"namespace", runtime.Namespace, "name", runtime.Name)
+	}
+
+	log.Info("Graceful shutdown completed for TrainingRuntimes")
+	return nil
+}
+
 func (r *TrainingRuntimeReconciler) NotifyTrainJobUpdate(oldJob, newJob *trainer.TrainJob) {
 	var runtimeNSName *types.NamespacedName
 	switch {

--- a/pkg/controller/trainingruntime_controller_test.go
+++ b/pkg/controller/trainingruntime_controller_test.go
@@ -222,3 +222,122 @@ func TestNotifyTrainJobUpdate_TrainingRuntimeReconciler(t *testing.T) {
 		})
 	}
 }
+
+// TestGracefulShutdown_TrainingRuntimeReconciler tests the graceful shutdown behavior
+// for RHOAIENG-42316: Stuck Trainer CR when disabling Trainer component
+func TestGracefulShutdown_TrainingRuntimeReconciler(t *testing.T) {
+	cases := map[string]struct {
+		runtimes                []trainer.TrainingRuntime
+		wantRemainingFinalizers map[string][]string // runtime namespace/name -> finalizers
+		wantDeleted             []string            // runtime namespace/name that should be deleted
+	}{
+		"removes finalizer from terminating TrainingRuntime": {
+			runtimes: []trainer.TrainingRuntime{
+				*utiltesting.MakeTrainingRuntimeWrapper("default", "runtime-terminating").
+					Finalizers(constants.ResourceInUseFinalizer).
+					DeletionTimestamp(metav1.Now()).
+					Obj(),
+			},
+			wantDeleted: []string{"default/runtime-terminating"}, // Deleted after finalizer removed
+		},
+		"keeps finalizer on non-terminating TrainingRuntime": {
+			runtimes: []trainer.TrainingRuntime{
+				*utiltesting.MakeTrainingRuntimeWrapper("default", "runtime-active").
+					Finalizers(constants.ResourceInUseFinalizer).
+					Obj(),
+			},
+			wantRemainingFinalizers: map[string][]string{
+				"default/runtime-active": {constants.ResourceInUseFinalizer}, // Finalizer should remain
+			},
+		},
+		"handles multiple runtimes across namespaces": {
+			runtimes: []trainer.TrainingRuntime{
+				*utiltesting.MakeTrainingRuntimeWrapper("ns1", "runtime-terminating").
+					Finalizers(constants.ResourceInUseFinalizer).
+					DeletionTimestamp(metav1.Now()).
+					Obj(),
+				*utiltesting.MakeTrainingRuntimeWrapper("ns2", "runtime-active").
+					Finalizers(constants.ResourceInUseFinalizer).
+					Obj(),
+				*utiltesting.MakeTrainingRuntimeWrapper("ns3", "runtime-terminating-multi").
+					Finalizers(constants.ResourceInUseFinalizer, "another-finalizer").
+					DeletionTimestamp(metav1.Now()).
+					Obj(),
+			},
+			wantDeleted: []string{"ns1/runtime-terminating"}, // Deleted after last finalizer removed
+			wantRemainingFinalizers: map[string][]string{
+				"ns2/runtime-active":            {constants.ResourceInUseFinalizer}, // Kept (not terminating)
+				"ns3/runtime-terminating-multi": {"another-finalizer"},              // Only ResourceInUseFinalizer removed
+			},
+		},
+		"does not fail on runtime without finalizer": {
+			runtimes: []trainer.TrainingRuntime{
+				*utiltesting.MakeTrainingRuntimeWrapper("default", "runtime-active-no-finalizer").
+					Obj(),
+			},
+			wantRemainingFinalizers: map[string][]string{
+				"default/runtime-active-no-finalizer": nil, // No finalizer to remove, not terminating
+			},
+		},
+		"handles empty list": {
+			runtimes:                []trainer.TrainingRuntime{},
+			wantRemainingFinalizers: map[string][]string{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Build client with test resources
+			builder := utiltesting.NewClientBuilder()
+			for i := range tc.runtimes {
+				builder = builder.WithObjects(&tc.runtimes[i])
+			}
+			cli := builder.Build()
+
+			r := NewTrainingRuntimeReconciler(cli, nil)
+
+			// Call GracefulShutdown
+			err := r.GracefulShutdown(ctx)
+			if err != nil {
+				t.Errorf("GracefulShutdown returned unexpected error: %v", err)
+			}
+
+			// Helper to parse namespace/name from key
+			parseKey := func(runtimeKey string) (string, string) {
+				for i, ch := range runtimeKey {
+					if ch == '/' {
+						return runtimeKey[:i], runtimeKey[i+1:]
+					}
+				}
+				return "", ""
+			}
+
+			// Verify resources that should be deleted
+			for _, runtimeKey := range tc.wantDeleted {
+				namespace, name := parseKey(runtimeKey)
+				var gotRuntime trainer.TrainingRuntime
+				err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &gotRuntime)
+				if err == nil {
+					t.Errorf("Expected TrainingRuntime %s to be deleted, but it still exists", runtimeKey)
+				}
+			}
+
+			// Verify finalizers on resources that should remain
+			for runtimeKey, wantFinalizers := range tc.wantRemainingFinalizers {
+				namespace, name := parseKey(runtimeKey)
+				var gotRuntime trainer.TrainingRuntime
+				err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &gotRuntime)
+				if err != nil {
+					t.Errorf("Failed to get TrainingRuntime %s: %v", runtimeKey, err)
+					continue
+				}
+
+				if diff := cmp.Diff(wantFinalizers, gotRuntime.Finalizers); len(diff) != 0 {
+					t.Errorf("Unexpected finalizers for %s (-want, +got):\n%s", runtimeKey, diff)
+				}
+			}
+		})
+	}
+}

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -106,7 +106,7 @@ func (f *Framework) RunManager(cfg *rest.Config, startControllers bool) (context
 	gomega.ExpectWithOffset(1, runtimes).NotTo(gomega.BeNil())
 
 	if startControllers {
-		failedCtrlName, err := controller.SetupControllers(mgr, runtimes, ctrlpkg.Options{
+		failedCtrlName, _, err := controller.SetupControllers(mgr, runtimes, ctrlpkg.Options{
 			// controller-runtime v0.19+ validates controller names are unique, to make sure
 			// exported Prometheus metrics for each controller do not conflict. The current check
 			// relies on static state that's not compatible with testing execution model.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Operator now implements graceful shutdown, ensuring clean resource cleanup and orderly termination during shutdown.

* **Tests**
  * Added comprehensive unit test coverage for graceful shutdown functionality, validating resource cleanup across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->