### PR TITLE
Sanitize NaN/Infinity in metrics JSON before parsing

### DIFF
--- a/pkg/rhai/progression/progression.go
+++ b/pkg/rhai/progression/progression.go
@@ -17,11 +17,13 @@ limitations under the License.
 package progression
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strconv"
 	"sync"
 	"time"
@@ -282,14 +284,34 @@ func PollTrainingProgress(ctx context.Context, pod *corev1.Pod, metricsPort stri
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
+	sanitized := sanitizeJSON(body)
+	if !bytes.Equal(body, sanitized) {
+		ctrl.Log.V(1).Info("Metrics JSON contained NaN/Infinity values, replaced with null", "pod", pod.Name)
+	}
 	var status TrainerStatus
-	if err := json.Unmarshal(body, &status); err != nil {
+	if err := json.Unmarshal(sanitized, &status); err != nil {
 		return nil, fmt.Errorf("failed to parse metrics JSON: %w", err)
 	}
 
 	cleanInvalidMetrics(&status)
 
 	return &status, nil
+}
+
+// sanitizeJSON replaces NaN and Infinity values with null in JSON strings.
+// Python's json.dumps() allows these by default, but they are not valid JSON,
+// causing Go's json.Unmarshal to fail.
+// jsonSanitizer matches quoted strings (to skip them) or bare NaN/Infinity tokens (to replace).
+// By matching strings first, NaN/Infinity inside string values are preserved unchanged.
+var jsonSanitizer = regexp.MustCompile(`"(?:[^"\\]|\\.)*"|-?Infinity|NaN`)
+
+func sanitizeJSON(data []byte) []byte {
+	return jsonSanitizer.ReplaceAllFunc(data, func(match []byte) []byte {
+		if match[0] == '"' {
+			return match // preserve quoted strings
+		}
+		return []byte("null")
+	})
 }
 
 // cleanInvalidMetrics removes invalid values while keeping valid fields.
@@ -494,8 +516,13 @@ func CaptureMetricsFromTerminationMessage(ctx context.Context, pod *corev1.Pod) 
 		}
 
 		// Parse JSON from termination message
+		raw := []byte(message)
+		sanitized := sanitizeJSON(raw)
+		if !bytes.Equal(raw, sanitized) {
+			ctrl.Log.V(1).Info("Termination message JSON contained NaN/Infinity values, replaced with null", "pod", pod.Name)
+		}
 		var status AnnotationStatus
-		if err := json.Unmarshal([]byte(message), &status); err != nil {
+		if err := json.Unmarshal(sanitized, &status); err != nil {
 			return nil, fmt.Errorf("failed to parse termination message JSON: %w", err)
 		}
 

--- a/pkg/rhai/progression/progression_test.go
+++ b/pkg/rhai/progression/progression_test.go
@@ -271,6 +271,53 @@ func TestPollTrainingProgress(t *testing.T) {
 			wantStatus:     nil,
 			wantErr:        true,
 		},
+		{
+			name: "NaN and Infinity values are sanitized to null",
+			responseBody: `{
+				"progressPercentage": 100,
+				"estimatedRemainingSeconds": 0,
+				"currentStep": 50,
+				"totalSteps": 50,
+				"currentEpoch": 5,
+				"totalEpochs": 5,
+				"trainMetrics": {"loss": 0.0, "grad_norm": NaN, "learning_rate": 1e-06},
+				"evalMetrics": {"eval_loss": NaN, "eval_runtime": 0.04}
+			}`,
+			responseStatus: http.StatusOK,
+			wantStatus: &TrainerStatus{
+				ProgressPercentage:        ptrInt(100),
+				EstimatedRemainingSeconds: ptrInt(0),
+				CurrentStep:               ptrInt(50),
+				TotalSteps:                ptrInt(50),
+				CurrentEpoch:              ptrFloat64(5),
+				TotalEpochs:               ptrInt(5),
+				TrainMetrics: map[string]interface{}{
+					"loss":          0.0,
+					"grad_norm":     nil,
+					"learning_rate": 1e-06,
+				},
+				EvalMetrics: map[string]interface{}{
+					"eval_loss":    nil,
+					"eval_runtime": 0.04,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative Infinity is sanitized to null",
+			responseBody: `{
+				"progressPercentage": 50,
+				"trainMetrics": {"loss": -Infinity}
+			}`,
+			responseStatus: http.StatusOK,
+			wantStatus: &TrainerStatus{
+				ProgressPercentage: ptrInt(50),
+				TrainMetrics: map[string]interface{}{
+					"loss": nil,
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -532,6 +579,74 @@ func TestGetPrimaryPod(t *testing.T) {
 
 			if !tt.wantErr && pod == nil {
 				t.Error("GetPrimaryPod() returned nil pod")
+			}
+		})
+	}
+}
+
+func TestSanitizeJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "NaN replaced with null",
+			input: `{"grad_norm": NaN, "loss": 0.5}`,
+			want:  `{"grad_norm": null, "loss": 0.5}`,
+		},
+		{
+			name:  "Infinity replaced with null",
+			input: `{"loss": Infinity}`,
+			want:  `{"loss": null}`,
+		},
+		{
+			name:  "negative Infinity replaced with null",
+			input: `{"loss": -Infinity}`,
+			want:  `{"loss": null}`,
+		},
+		{
+			name:  "multiple NaN values",
+			input: `{"grad_norm": NaN, "eval_loss": NaN, "loss": 0.1}`,
+			want:  `{"grad_norm": null, "eval_loss": null, "loss": 0.1}`,
+		},
+		{
+			name:  "no special values unchanged",
+			input: `{"loss": 0.5, "step": 100}`,
+			want:  `{"loss": 0.5, "step": 100}`,
+		},
+		{
+			name:  "NaN in string value not replaced",
+			input: `{"message": "Error: NaN detected", "grad_norm": NaN}`,
+			want:  `{"message": "Error: NaN detected", "grad_norm": null}`,
+		},
+		{
+			name:  "NaN inside string with colon prefix not replaced",
+			input: `{"message": "grad_norm: NaN, skipping", "grad_norm": NaN}`,
+			want:  `{"message": "grad_norm: NaN, skipping", "grad_norm": null}`,
+		},
+		{
+			name:  "NaN in nested object",
+			input: `{"metrics": {"grad_norm": NaN, "loss": 0.5}}`,
+			want:  `{"metrics": {"grad_norm": null, "loss": 0.5}}`,
+		},
+		{
+			name:  "NaN in array",
+			input: `{"values": [NaN, 1.0, -Infinity]}`,
+			want:  `{"values": [null, 1.0, null]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(sanitizeJSON([]byte(tt.input)))
+			if got != tt.want {
+				t.Errorf("sanitizeJSON() = %q, want %q", got, tt.want)
+			}
+			// Verify result is valid JSON
+			var m map[string]interface{}
+			if err := json.Unmarshal([]byte(got), &m); err != nil {
+				t.Errorf("sanitizeJSON() produced invalid JSON: %v", err)
 			}
 		})
 	}
@@ -1266,6 +1381,39 @@ func TestCaptureMetricsFromTerminationMessage(t *testing.T) {
 			},
 			wantErr: true,
 			wantNil: true,
+		},
+		{
+			name: "NaN and Infinity in termination message are sanitized",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "node",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									Message: `{"progressPercentage": 100, "estimatedRemainingSeconds": 0, "currentStep": 50, "totalSteps": 50, "trainMetrics": {"loss": 0.0, "grad_norm": NaN}, "evalMetrics": {"eval_loss": NaN, "eval_runtime": 0.04}}`,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantNil: false,
+			checkFunc: func(t *testing.T, status *AnnotationStatus) {
+				if status.ProgressPercentage == nil || *status.ProgressPercentage != 100 {
+					t.Errorf("ProgressPercentage = %v, want 100", status.ProgressPercentage)
+				}
+				if status.TrainMetrics == nil {
+					t.Fatal("TrainMetrics is nil")
+				}
+				if status.TrainMetrics["grad_norm"] != nil {
+					t.Errorf("grad_norm should be nil (sanitized from NaN), got %v", status.TrainMetrics["grad_norm"])
+				}
+				if status.EvalMetrics["eval_loss"] != nil {
+					t.Errorf("eval_loss should be nil (sanitized from NaN), got %v", status.EvalMetrics["eval_loss"])
+				}
+			},
 		},
 		{
 			name: "invalid JSON in termination message",


### PR DESCRIPTION
Python's json.dumps() allows NaN and Infinity by default, but these are not valid JSON per the spec. When training metrics contain these values (e.g., grad_norm when loss=0, eval_loss with bf16 on ROCm), Go's json.Unmarshal fails, causing the operator to never capture training progress.

Add sanitizeJSON() to replace NaN/Infinity with null before parsing in both PollTrainingProgress and CaptureMetricsFromTerminationMessage.

Ref: RHOAIENG-56898

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metrics parsing now treats non-standard numeric tokens (NaN, Infinity, -Infinity) as null in JSON payloads to prevent errors when reporting training progress or termination-message metrics; quoted string contents are preserved. Sanitized payloads emit a low-verbosity debug log when modifications occur.

* **Tests**
  * Added tests for polling and termination-message handling with non-standard numeric values and a unit test verifying sanitization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->