### PR TITLE
Fix flaky failure e2e test: increase training duration for reliable polling

### DIFF
--- a/test/e2e/rhai/resources/failing-test-runtime.yaml
+++ b/test/e2e/rhai/resources/failing-test-runtime.yaml
@@ -66,15 +66,17 @@ spec:
                           # Wait briefly for server to be ready
                           time.sleep(1)
 
-                          # Fast training that will fail at 50% (3 seconds total)
+                          # Training that will fail at 50% (~8 seconds total)
+                          # Must run long enough for controller to poll progress > 0
+                          # with a 2s poll interval (at least 3-4 poll cycles).
                           print("Starting training that will fail...")
                           total_steps = 30
                           fail_at_step = 15  # Fail at 50%
 
                           for step in range(fail_at_step):
-                              time.sleep(0.2)  # 0.2s per step
+                              time.sleep(0.5)  # 0.5s per step
                               progress = int((step / total_steps) * 100)
-                              remaining = int((total_steps - step) * 0.2)
+                              remaining = int((total_steps - step) * 0.5)
 
                               MetricsHandler.progress_data = {
                                   "progressPercentage": progress,


### PR DESCRIPTION
## Summary
- The `"should capture final status even when job fails"` e2e test was flaky because the failing training runtime ran only ~3 seconds (15 steps × 0.2s), which was too short for the controller's 2s poll interval to capture `progressPercentage > 0` before the job crashed.
- Increased per-step sleep from 0.2s to 0.5s (~8s total training), giving the controller 3-4 poll cycles to reliably capture progress > 0.

## Test plan
- [x] Verified the only change is the step duration in `failing-test-runtime.yaml`
- [x] RHAI progression e2e test suite passes with the updated runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test configuration to improve reliability of workload progress observation by adjusting timing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->