### PR TITLE
fix: ensure ReconcileProgression runs even when TrainJob status changes

### DIFF
--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -141,7 +141,9 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if !equality.Semantic.DeepEqual(&trainJob.Status, originStatus) {
-		return ctrl.Result{}, errors.Join(err, r.client.Status().Update(ctx, &trainJob))
+		if statusUpdateErr := r.client.Status().Update(ctx, &trainJob); statusUpdateErr != nil {
+			return ctrl.Result{}, errors.Join(err, statusUpdateErr)
+		}
 	}
 
 	// RHAI progression tracking (use APIReader to avoid pod watches)

--- a/pkg/rhai/progression/progression.go
+++ b/pkg/rhai/progression/progression.go
@@ -467,7 +467,7 @@ func IsFinalStatusCaptured(trainJob *trainer.TrainJob) bool {
 
 	hasZeroRemaining := status.EstimatedRemainingSeconds != nil && *status.EstimatedRemainingSeconds == 0
 	hasCompleteSummary := status.EstimatedRemainingTimeSummary == "complete" ||
-		status.EstimatedRemainingTimeSummary == "0 seconds"
+		status.EstimatedRemainingTimeSummary == "complete (early stopped)"
 
 	if hasZeroRemaining || hasCompleteSummary {
 		return true
@@ -672,23 +672,17 @@ func PollAndUpdateFinalProgress(ctx context.Context, c client.Client, reader cli
 }
 
 func updateFinalStatus(trainJob *trainer.TrainJob, completed bool) error {
-	if trainJob.Annotations == nil {
-		return nil // No existing status to update
-	}
-
-	statusJSON, exists := trainJob.Annotations[constants.AnnotationTrainerStatus]
-	if !exists || statusJSON == "" {
-		return nil // No existing status to update
-	}
-
 	var status AnnotationStatus
-	if err := json.Unmarshal([]byte(statusJSON), &status); err != nil {
-		return err
+
+	if trainJob.Annotations != nil {
+		if statusJSON, exists := trainJob.Annotations[constants.AnnotationTrainerStatus]; exists && statusJSON != "" {
+			if err := json.Unmarshal([]byte(statusJSON), &status); err != nil {
+				return err
+			}
+		}
 	}
 
-	// Only update summary - don't modify actual metrics (progress %, remaining time, etc.)
 	if completed {
-		// Detect early stop: currentStep < totalSteps
 		earlyStop := false
 		if status.CurrentStep != nil && status.TotalSteps != nil && *status.TotalSteps > 0 {
 			if *status.CurrentStep < *status.TotalSteps {
@@ -696,12 +690,18 @@ func updateFinalStatus(trainJob *trainer.TrainJob, completed bool) error {
 			}
 		}
 		if earlyStop {
-			status.EstimatedRemainingTimeSummary = "early stopped"
+			status.EstimatedRemainingTimeSummary = "complete (early stopped)"
 		} else {
 			status.EstimatedRemainingTimeSummary = "complete"
 		}
+		// Synthesize progress if no prior annotation existed
+		if status.ProgressPercentage == nil {
+			pct := 100
+			status.ProgressPercentage = &pct
+			remaining := 0
+			status.EstimatedRemainingSeconds = &remaining
+		}
 	} else {
-		// For failed jobs: show progress context in summary
 		progressPct := 0
 		if status.ProgressPercentage != nil {
 			progressPct = *status.ProgressPercentage
@@ -752,7 +752,7 @@ func ReconcileProgression(ctx context.Context, c client.Client, reader client.Re
 			log.V(1).Info("Pod not available for final metrics poll, will retry", "completed", isCompleted)
 			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		}
-		log.Info("Captured final training progress from HTTP poll", "completed", isCompleted)
+		log.Info("Captured final training progress", "completed", isCompleted)
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->


## Summary

- ReconcileProgression was unreachable whenever a status update occurred in the same reconcile loop, causing the trainerStatus annotation to never be written during short-lived training jobs
- Now the controller always reaches progression tracking after status updates, and updateFinalStatus synthesizes a minimal annotation for completed jobs that were never polled

## Root cause
The reconciler had an early return after Status().Update, meaning ReconcileProgression was only called when status was unchanged. For fast-completing jobs (< 30s), status churn during startup meant zero polls ever ran. After completion, CaptureMetricsFromTerminationMessage failed (mock runtimes don't write one), HTTP poll failed (pod terminated), and updateFinalStatus returned nil because there was no existing annotation to update.

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for training job status updates.
  * Enhanced support for jobs with missing status annotations.
  * Corrected progress reporting and status summary display for early-stopped training jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->