### PR TITLE
Fix/rhoaieng 59039 rhai e2e v2

### DIFF
--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -140,13 +140,24 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		err = errors.Join(err, statusErr)
 	}
 
-	if !equality.Semantic.DeepEqual(&trainJob.Status, originStatus) {
-		return ctrl.Result{}, errors.Join(err, r.client.Status().Update(ctx, &trainJob))
-	}
+	// Save the reconciled status before calling ReconcileProgression. When
+	// ReconcileProgression patches the TrainJob's annotations the Kubernetes API
+	// server responds with the current persisted object, which overwrites
+	// trainJob.Status in memory and loses the status changes set above.
+	reconciledStatus := trainJob.Status.DeepCopy()
 
 	// RHAI progression tracking (use APIReader to avoid pod watches)
 	result, progressionErr := progression.ReconcileProgression(ctx, r.client, r.apiReader, log, &trainJob)
-	return result, errors.Join(err, progressionErr)
+	err = errors.Join(err, progressionErr)
+
+	// Restore status that may have been overwritten by the annotation patch response.
+	trainJob.Status = *reconciledStatus
+
+	if !equality.Semantic.DeepEqual(&trainJob.Status, originStatus) {
+		return result, errors.Join(err, r.client.Status().Update(ctx, &trainJob))
+	}
+
+	return result, err
 }
 
 func (r *TrainJobReconciler) reconcileObjects(ctx context.Context, runtime jobruntimes.Runtime, trainJob *trainer.TrainJob) error {

--- a/pkg/rhai/progression/progression.go
+++ b/pkg/rhai/progression/progression.go
@@ -274,7 +274,7 @@ func PollTrainingProgress(ctx context.Context, pod *corev1.Pod, metricsPort stri
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch metrics from %s: %w", metricsURL, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code %d from metrics endpoint", resp.StatusCode)
@@ -666,8 +666,8 @@ func PollAndUpdateFinalProgress(ctx context.Context, c client.Client, reader cli
 	}
 	// updateFinalStatus is a no-op when no prior annotation exists (metrics were never polled).
 	// Skip the patch and signal "captured" to prevent an infinite requeue loop.
-	oldAnnotation, _ := oldTrainJob.Annotations[constants.AnnotationTrainerStatus]
-	newAnnotation, _ := trainJob.Annotations[constants.AnnotationTrainerStatus]
+	oldAnnotation := oldTrainJob.Annotations[constants.AnnotationTrainerStatus]
+	newAnnotation := trainJob.Annotations[constants.AnnotationTrainerStatus]
 	if oldAnnotation == newAnnotation {
 		return true, nil
 	}

--- a/pkg/rhai/progression/progression.go
+++ b/pkg/rhai/progression/progression.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -467,7 +468,7 @@ func IsFinalStatusCaptured(trainJob *trainer.TrainJob) bool {
 
 	hasZeroRemaining := status.EstimatedRemainingSeconds != nil && *status.EstimatedRemainingSeconds == 0
 	hasCompleteSummary := status.EstimatedRemainingTimeSummary == "complete" ||
-		status.EstimatedRemainingTimeSummary == "0 seconds"
+		status.EstimatedRemainingTimeSummary == "complete (early stopped)"
 
 	if hasZeroRemaining || hasCompleteSummary {
 		return true
@@ -663,6 +664,13 @@ func PollAndUpdateFinalProgress(ctx context.Context, c client.Client, reader cli
 	if err := updateFinalStatus(trainJob, completed); err != nil {
 		return false, fmt.Errorf("failed to update final status: %w", err)
 	}
+	// updateFinalStatus is a no-op when no prior annotation exists (metrics were never polled).
+	// Skip the patch and signal "captured" to prevent an infinite requeue loop.
+	oldAnnotation, _ := oldTrainJob.Annotations[constants.AnnotationTrainerStatus]
+	newAnnotation, _ := trainJob.Annotations[constants.AnnotationTrainerStatus]
+	if oldAnnotation == newAnnotation {
+		return true, nil
+	}
 	patch := client.MergeFrom(oldTrainJob)
 	if err := c.Patch(ctx, trainJob, patch); err != nil {
 		return false, fmt.Errorf("failed to patch TrainJob annotations: %w", err)
@@ -672,23 +680,22 @@ func PollAndUpdateFinalProgress(ctx context.Context, c client.Client, reader cli
 }
 
 func updateFinalStatus(trainJob *trainer.TrainJob, completed bool) error {
-	if trainJob.Annotations == nil {
-		return nil // No existing status to update
-	}
+	var status AnnotationStatus
 
+	// Only update an annotation that was already populated by live metric polling.
+	// If the metrics endpoint was never reachable, no annotation should be created.
+	if trainJob.Annotations == nil {
+		return nil
+	}
 	statusJSON, exists := trainJob.Annotations[constants.AnnotationTrainerStatus]
 	if !exists || statusJSON == "" {
-		return nil // No existing status to update
+		return nil
 	}
-
-	var status AnnotationStatus
 	if err := json.Unmarshal([]byte(statusJSON), &status); err != nil {
 		return err
 	}
 
-	// Only update summary - don't modify actual metrics (progress %, remaining time, etc.)
 	if completed {
-		// Detect early stop: currentStep < totalSteps
 		earlyStop := false
 		if status.CurrentStep != nil && status.TotalSteps != nil && *status.TotalSteps > 0 {
 			if *status.CurrentStep < *status.TotalSteps {
@@ -696,12 +703,11 @@ func updateFinalStatus(trainJob *trainer.TrainJob, completed bool) error {
 			}
 		}
 		if earlyStop {
-			status.EstimatedRemainingTimeSummary = "early stopped"
+			status.EstimatedRemainingTimeSummary = "complete (early stopped)"
 		} else {
 			status.EstimatedRemainingTimeSummary = "complete"
 		}
 	} else {
-		// For failed jobs: show progress context in summary
 		progressPct := 0
 		if status.ProgressPercentage != nil {
 			progressPct = *status.ProgressPercentage
@@ -745,6 +751,12 @@ func ReconcileProgression(ctx context.Context, c client.Client, reader client.Re
 		// Capture final metrics (termination message + HTTP polling fallback)
 		captured, pollErr := PollAndUpdateFinalProgress(ctx, c, reader, trainJob, isCompleted)
 		if pollErr != nil {
+			// If the API server rejects the patch (e.g. admission webhook rejects because
+			// the TrainingRuntime was already deleted), there is no point retrying.
+			if apierrors.IsInvalid(pollErr) || apierrors.IsForbidden(pollErr) {
+				log.V(1).Info("Cannot capture final training progress - unrecoverable API error, skipping retry", "error", pollErr)
+				return ctrl.Result{}, nil
+			}
 			log.V(1).Info("Failed to capture final training progress, will retry", "error", pollErr, "completed", isCompleted)
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
@@ -752,7 +764,7 @@ func ReconcileProgression(ctx context.Context, c client.Client, reader client.Re
 			log.V(1).Info("Pod not available for final metrics poll, will retry", "completed", isCompleted)
 			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		}
-		log.Info("Captured final training progress from HTTP poll", "completed", isCompleted)
+		log.Info("Captured final training progress", "completed", isCompleted)
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Fixes two bugs in the RHAI progression tracking controller that were causing e2e tests to fail.

**Bug 1** — TrainJobFailed condition silently lost during reconciliation
When ReconcileProgression patches the TrainJob annotations, the Kubernetes API server responds with the full persisted object, overwriting trainJob.Status in memory. This caused the TrainJobFailed condition set by setTrainJobStatus to be silently discarded before r.client.Status().Update() was called, so the condition never reached the API server and the job appeared to hang forever.

**Fix:** snapshot trainJob.Status before calling ReconcileProgression, then restore it afterward so the conditions we own are not lost.

**Bug 2** — trainerStatus annotation synthesized when metrics were never reachable
updateFinalStatus was creating a trainerStatus annotation even when the metrics endpoint had never been reachable during the job (i.e. no prior annotation existed). The e2e test explicitly expects no annotation in that scenario.

**Fix:** updateFinalStatus returns early if no existing annotation is found. PollAndUpdateFinalProgress skips the patch and returns (true, nil) when no annotation change was made, preventing an infinite requeue loop.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training job status preservation during reconciliation steps.
  * Enhanced error handling for invalid or forbidden API responses in progression tracking.
  * Fixed completion detection for early-stopped training jobs.
  * Reduced unnecessary retries on specific error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->