### PR TITLE
Update cuda and cpu image references from torch291 to torch210

### DIFF
--- a/manifests/rhoai/imagestreams/training-hub-universal-cpu-imagestream.yaml
+++ b/manifests/rhoai/imagestreams/training-hub-universal-cpu-imagestream.yaml
@@ -20,7 +20,7 @@ spec:
         opendatahub.io/notebook-software: |
           [
             {"name": "Python", "version": "v3.12"},
-            {"name": "PyTorch", "version": "2.9.1"},
+            {"name": "PyTorch", "version": "2.10.0"},
             {"name": "Training Hub", "version": "v0.6.0"}
           ]
         opendatahub.io/notebook-python-dependencies: |
@@ -29,11 +29,11 @@ spec:
             {"name": "accelerate", "version": "1.12.0"},
             {"name": "peft", "version": "0.18.1"},
             {"name": "trl", "version": "0.24.0"},
-            {"name": "triton", "version": "3.5.1"}
+            {"name": "triton", "version": "3.6.0"}
           ]
-        openshift.io/imported-from: quay.io/opendatahub/odh-th06-cpu-torch291-py312
+        openshift.io/imported-from: quay.io/opendatahub/odh-th06-cpu-torch210-py312
       from:
         kind: DockerImage
-        name: quay.io/opendatahub/odh-th06-cpu-torch291-py312:odh-3.4
+        name: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4
       referencePolicy:
         type: Source

--- a/manifests/rhoai/imagestreams/training-hub-universal-cuda-imagestream.yaml
+++ b/manifests/rhoai/imagestreams/training-hub-universal-cuda-imagestream.yaml
@@ -22,7 +22,7 @@ spec:
           [
             {"name": "CUDA", "version": "13.0"},
             {"name": "Python", "version": "v3.12"},
-            {"name": "PyTorch", "version": "2.9.1"},
+            {"name": "PyTorch", "version": "2.10.0"},
             {"name": "Training Hub", "version": "v0.6.0"}
           ]
         opendatahub.io/notebook-python-dependencies: |
@@ -33,11 +33,11 @@ spec:
             {"name": "trl", "version": "0.24.0"},
             {"name": "deepspeed", "version": "0.18.9"},
             {"name": "flash-attn", "version": "2.8.3"},
-            {"name": "triton", "version": "3.5.1"}
+            {"name": "triton", "version": "3.6.0"}
           ]
-        openshift.io/imported-from: quay.io/opendatahub/odh-th06-cuda130-torch291-py312
+        openshift.io/imported-from: quay.io/opendatahub/odh-th06-cuda130-torch210-py312
       from:
         kind: DockerImage
-        name: quay.io/opendatahub/odh-th06-cuda130-torch291-py312:odh-3.4
+        name: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
       referencePolicy:
         type: Source

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -59,7 +59,7 @@ replacements:
     kind: ConfigMap
     name: rhoai-config
     version: v1
-    fieldPath: data.odh-th06-cuda130-torch291-py312-image
+    fieldPath: data.odh-th06-cuda130-torch210-py312-image
   targets:
   - select:
       kind: ClusterTrainingRuntime
@@ -85,7 +85,7 @@ replacements:
     kind: ConfigMap
     name: rhoai-config
     version: v1
-    fieldPath: data.odh-th06-cpu-torch291-py312-image
+    fieldPath: data.odh-th06-cpu-torch210-py312-image
   targets:
   - select:
       kind: ClusterTrainingRuntime
@@ -93,16 +93,16 @@ replacements:
     fieldPaths:
     - spec.template.spec.replicatedJobs.[name=node].template.spec.template.spec.containers.[name=node].image
 
-# Replace image for torch-distributed-cuda130-torch291-py312
+# Replace image for torch-distributed-cuda130-torch210-py312
 - source:
     kind: ConfigMap
     name: rhoai-config
     version: v1
-    fieldPath: data.odh-th06-cuda130-torch291-py312-image
+    fieldPath: data.odh-th06-cuda130-torch210-py312-image
   targets:
   - select:
       kind: ClusterTrainingRuntime
-      name: torch-distributed-cuda130-torch291-py312
+      name: torch-distributed-cuda130-torch210-py312
     fieldPaths:
     - spec.template.spec.replicatedJobs.[name=node].template.spec.template.spec.containers.[name=node].image
 
@@ -119,16 +119,16 @@ replacements:
     fieldPaths:
     - spec.template.spec.replicatedJobs.[name=node].template.spec.template.spec.containers.[name=node].image
 
-# Replace image for torch-distributed-cpu-torch291-py312
+# Replace image for torch-distributed-cpu-torch210-py312
 - source:
     kind: ConfigMap
     name: rhoai-config
     version: v1
-    fieldPath: data.odh-th06-cpu-torch291-py312-image
+    fieldPath: data.odh-th06-cpu-torch210-py312-image
   targets:
   - select:
       kind: ClusterTrainingRuntime
-      name: torch-distributed-cpu-torch291-py312
+      name: torch-distributed-cpu-torch210-py312
     fieldPaths:
     - spec.template.spec.replicatedJobs.[name=node].template.spec.template.spec.containers.[name=node].image
 
@@ -137,7 +137,7 @@ replacements:
     kind: ConfigMap
     name: rhoai-config
     version: v1
-    fieldPath: data.odh-th06-cuda130-torch291-py312-image
+    fieldPath: data.odh-th06-cuda130-torch210-py312-image
   targets:
   - select:
       kind: ClusterTrainingRuntime
@@ -163,7 +163,7 @@ replacements:
     kind: ConfigMap
     name: rhoai-config
     version: v1
-    fieldPath: data.odh-th06-cpu-torch291-py312-image
+    fieldPath: data.odh-th06-cpu-torch210-py312-image
   targets:
   - select:
       kind: ClusterTrainingRuntime
@@ -184,16 +184,16 @@ replacements:
     fieldPaths:
     - spec.template.spec.replicatedJobs.[name=node].template.spec.template.spec.containers.[name=node].image
 
-# Replace image for training-hub-th06-cuda130-torch291-py312
+# Replace image for training-hub-th06-cuda130-torch210-py312
 - source:
     kind: ConfigMap
     name: rhoai-config
     version: v1
-    fieldPath: data.odh-th06-cuda130-torch291-py312-image
+    fieldPath: data.odh-th06-cuda130-torch210-py312-image
   targets:
   - select:
       kind: ClusterTrainingRuntime
-      name: training-hub-th06-cuda130-torch291-py312
+      name: training-hub-th06-cuda130-torch210-py312
     fieldPaths:
     - spec.template.spec.replicatedJobs.[name=node].template.spec.template.spec.containers.[name=node].image
 
@@ -210,16 +210,16 @@ replacements:
     fieldPaths:
     - spec.template.spec.replicatedJobs.[name=node].template.spec.template.spec.containers.[name=node].image
 
-# Replace image for training-hub-th06-cpu-torch291-py312
+# Replace image for training-hub-th06-cpu-torch210-py312
 - source:
     kind: ConfigMap
     name: rhoai-config
     version: v1
-    fieldPath: data.odh-th06-cpu-torch291-py312-image
+    fieldPath: data.odh-th06-cpu-torch210-py312-image
   targets:
   - select:
       kind: ClusterTrainingRuntime
-      name: training-hub-th06-cpu-torch291-py312
+      name: training-hub-th06-cpu-torch210-py312
     fieldPaths:
     - spec.template.spec.replicatedJobs.[name=node].template.spec.template.spec.containers.[name=node].image
 

--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -1,10 +1,10 @@
 odh-kubeflow-trainer-controller-image=quay.io/opendatahub/trainer:odh-3.4.0
 odh-training-cuda128-torch29-py312-image=quay.io/opendatahub/odh-training-cuda128-torch29-py312@sha256:0be52d5775e95026c3899a208d9fbecb59489d48763664e842b92e66d3c112c8
 odh-training-rocm64-torch29-py312-image=quay.io/opendatahub/odh-training-rocm64-torch29-py312@sha256:80878d0d51fa6bc8957f669e7f3facac13669562d393a6bfc45ca8dff277c2fa
-odh-th06-cuda130-torch291-py312-image=quay.io/opendatahub/odh-th06-cuda130-torch291-py312:odh-3.4
+odh-th06-cuda130-torch210-py312-image=quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
 odh-th06-rocm64-torch291-py312-image=quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
-odh-th06-cpu-torch291-py312-image=quay.io/opendatahub/odh-th06-cpu-torch291-py312:odh-3.4
+odh-th06-cpu-torch210-py312-image=quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4
 odh-openmpi-cuda-image=quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-stable
-odh-training-universal-workbench-image-cuda-3-4=quay.io/opendatahub/odh-th06-cuda130-torch291-py312:odh-3.4
+odh-training-universal-workbench-image-cuda-3-4=quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
 odh-training-universal-workbench-image-rocm-3-4=quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
-odh-training-universal-workbench-image-cpu-3-4=quay.io/opendatahub/odh-th06-cpu-torch291-py312:odh-3.4
+odh-training-universal-workbench-image-cpu-3-4=quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4

--- a/manifests/rhoai/runtimes/kustomization.yaml
+++ b/manifests/rhoai/runtimes/kustomization.yaml
@@ -10,10 +10,10 @@ resources:
   - torch_distributed_rocm64_torch29_py312.yaml
   - torch_distributed_cuda128_torch29_py312.yaml
   - training_hub_th05_cuda128_torch29_py312.yaml
-  - torch_distributed_cuda130_torch291_py312.yaml
+  - torch_distributed_cuda130_torch210_py312.yaml
   - torch_distributed_rocm64_torch291_py312.yaml
-  - torch_distributed_cpu_torch291_py312.yaml
-  - training_hub_th06_cuda130_torch291_py312.yaml
+  - torch_distributed_cpu_torch210_py312.yaml
+  - training_hub_th06_cuda130_torch210_py312.yaml
   - training_hub_th06_rocm64_torch291_py312.yaml
-  - training_hub_th06_cpu_torch291_py312.yaml
+  - training_hub_th06_cpu_torch210_py312.yaml
   - openmpi_cuda.yaml

--- a/manifests/rhoai/runtimes/torch_distributed.yaml
+++ b/manifests/rhoai/runtimes/torch_distributed.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cuda130-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4

--- a/manifests/rhoai/runtimes/torch_distributed_cpu.yaml
+++ b/manifests/rhoai/runtimes/torch_distributed_cpu.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cpu-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4

--- a/manifests/rhoai/runtimes/torch_distributed_cpu_torch210_py312.yaml
+++ b/manifests/rhoai/runtimes/torch_distributed_cpu_torch210_py312.yaml
@@ -1,7 +1,7 @@
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
-  name: torch-distributed-cpu-torch291-py312
+  name: torch-distributed-cpu-torch210-py312
   labels:
     trainer.kubeflow.org/framework: torch
 spec:
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cpu-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4

--- a/manifests/rhoai/runtimes/torch_distributed_cuda130_torch210_py312.yaml
+++ b/manifests/rhoai/runtimes/torch_distributed_cuda130_torch210_py312.yaml
@@ -1,9 +1,9 @@
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
-  name: training-hub-th06-cpu-torch291-py312
+  name: torch-distributed-cuda130-torch210-py312
   labels:
-    trainer.kubeflow.org/framework: training-hub
+    trainer.kubeflow.org/framework: torch
 spec:
   mlPolicy:
     numNodes: 1
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cpu-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4

--- a/manifests/rhoai/runtimes/training_hub.yaml
+++ b/manifests/rhoai/runtimes/training_hub.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cuda130-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4

--- a/manifests/rhoai/runtimes/training_hub_cpu.yaml
+++ b/manifests/rhoai/runtimes/training_hub_cpu.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cpu-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4

--- a/manifests/rhoai/runtimes/training_hub_th06_cpu_torch210_py312.yaml
+++ b/manifests/rhoai/runtimes/training_hub_th06_cpu_torch210_py312.yaml
@@ -1,7 +1,7 @@
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
-  name: training-hub-th06-cuda130-torch291-py312
+  name: training-hub-th06-cpu-torch210-py312
   labels:
     trainer.kubeflow.org/framework: training-hub
 spec:
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cuda130-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4

--- a/manifests/rhoai/runtimes/training_hub_th06_cuda130_torch210_py312.yaml
+++ b/manifests/rhoai/runtimes/training_hub_th06_cuda130_torch210_py312.yaml
@@ -1,9 +1,9 @@
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
-  name: torch-distributed-cuda130-torch291-py312
+  name: training-hub-th06-cuda130-torch210-py312
   labels:
-    trainer.kubeflow.org/framework: torch
+    trainer.kubeflow.org/framework: training-hub
 spec:
   mlPolicy:
     numNodes: 1
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cuda130-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4


### PR DESCRIPTION
## Summary
- Renames runtime YAML files and updates all image references for **cuda** and **cpu** variants from `torch291` to `torch210`
- Covers params.env, kustomization.yaml, imagestreams, and all affected ClusterTrainingRuntime manifests
- **ROCm images are unchanged**

## Files changed
- 4 runtime files renamed (cuda130/cpu torch_distributed + training_hub)
- Content updated in 13 files total across `manifests/rhoai/`

## Test plan
- [ ] Verify kustomize build succeeds: `kustomize build manifests/rhoai/`
- [ ] Confirm new image names resolve correctly in the registry
- [ ] Deploy to test cluster and verify ClusterTrainingRuntimes reference correct images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated training runtime container images from PyTorch 2.9.1 to PyTorch 2.1.0 for CUDA 130 and CPU environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->