### PR TITLE
update to 3.5ea1 images

### DIFF
--- a/manifests/rhoai/imagestreams/training-hub-universal-cpu-imagestream.yaml
+++ b/manifests/rhoai/imagestreams/training-hub-universal-cpu-imagestream.yaml
@@ -15,7 +15,7 @@ spec:
   tags:
     - name: "3.4"
       annotations:
-        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: a66ec72
         opendatahub.io/notebook-software: |
           [
@@ -35,5 +35,29 @@ spec:
       from:
         kind: DockerImage
         name: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4
+      referencePolicy:
+        type: Source
+    - name: "3.5"
+      annotations:
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: a66ec72
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "Python", "version": "v3.12"},
+            {"name": "PyTorch", "version": "2.10.0"},
+            {"name": "Training Hub", "version": "v0.6.0"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "transformers", "version": "4.57.6"},
+            {"name": "accelerate", "version": "1.12.0"},
+            {"name": "peft", "version": "0.18.1"},
+            {"name": "trl", "version": "0.24.0"},
+            {"name": "triton", "version": "3.6.0"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/odh-th06-cpu-torch210-py312
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.5-ea1
       referencePolicy:
         type: Source

--- a/manifests/rhoai/imagestreams/training-hub-universal-cuda-imagestream.yaml
+++ b/manifests/rhoai/imagestreams/training-hub-universal-cuda-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
   tags:
     - name: "3.4"
       annotations:
-        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: a66ec72
         opendatahub.io/notebook-software: |
           [
@@ -39,5 +39,32 @@ spec:
       from:
         kind: DockerImage
         name: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
+      referencePolicy:
+        type: Source
+    - name: "3.5"
+      annotations:
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: a66ec72
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "CUDA", "version": "13.0"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "PyTorch", "version": "2.10.0"},
+            {"name": "Training Hub", "version": "v0.6.0"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "transformers", "version": "4.57.6"},
+            {"name": "accelerate", "version": "1.12.0"},
+            {"name": "peft", "version": "0.18.1"},
+            {"name": "trl", "version": "0.24.0"},
+            {"name": "deepspeed", "version": "0.18.9"},
+            {"name": "flash-attn", "version": "2.8.3"},
+            {"name": "triton", "version": "3.6.0"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/odh-th06-cuda130-torch210-py312
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1
       referencePolicy:
         type: Source

--- a/manifests/rhoai/imagestreams/training-hub-universal-rocm-imagestream.yaml
+++ b/manifests/rhoai/imagestreams/training-hub-universal-rocm-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
   tags:
     - name: "3.4"
       annotations:
-        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: a66ec72
         opendatahub.io/notebook-software: |
           [
@@ -39,5 +39,32 @@ spec:
       from:
         kind: DockerImage
         name: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
+      referencePolicy:
+        type: Source
+    - name: "3.5"
+      annotations:
+        opendatahub.io/workbench-image-recommended: 'true'
+        opendatahub.io/notebook-build-commit: a66ec72
+        opendatahub.io/notebook-software: |
+          [
+            {"name": "ROCm", "version": "6.4"},
+            {"name": "Python", "version": "v3.12"},
+            {"name": "PyTorch", "version": "2.9.1"},
+            {"name": "Training Hub", "version": "v0.6.0"}
+          ]
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name": "transformers", "version": "4.57.6"},
+            {"name": "accelerate", "version": "1.12.0"},
+            {"name": "peft", "version": "0.18.1"},
+            {"name": "trl", "version": "0.24.0"},
+            {"name": "deepspeed", "version": "0.18.9"},
+            {"name": "flash-attn", "version": "2.8.3"},
+            {"name": "triton", "version": "3.5.1"}
+          ]
+        openshift.io/imported-from: quay.io/opendatahub/odh-th06-rocm64-torch291-py312
+      from:
+        kind: DockerImage
+        name: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.5-ea1
       referencePolicy:
         type: Source

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -282,6 +282,51 @@ replacements:
     fieldPaths:
     - spec.tags.0.from.name
 
+# Replace image for training-hub-universal-cpu ImageStream (2026.2)
+- source:
+    kind: ConfigMap
+    name: rhoai-config
+    version: v1
+    fieldPath: data.odh-training-universal-workbench-image-cpu-3-5
+  targets:
+  - select:
+      group: image.openshift.io
+      kind: ImageStream
+      name: training-hub-universal-cpu
+      version: v1
+    fieldPaths:
+    - spec.tags.1.from.name
+
+# Replace image for training-hub-universal-cuda ImageStream (2026.2)
+- source:
+    kind: ConfigMap
+    name: rhoai-config
+    version: v1
+    fieldPath: data.odh-training-universal-workbench-image-cuda-3-5
+  targets:
+  - select:
+      group: image.openshift.io
+      kind: ImageStream
+      name: training-hub-universal-cuda
+      version: v1
+    fieldPaths:
+    - spec.tags.1.from.name
+
+# Replace image for training-hub-universal-rocm ImageStream (2026.2)
+- source:
+    kind: ConfigMap
+    name: rhoai-config
+    version: v1
+    fieldPath: data.odh-training-universal-workbench-image-rocm-3-5
+  targets:
+  - select:
+      group: image.openshift.io
+      kind: ImageStream
+      name: training-hub-universal-rocm
+      version: v1
+    fieldPaths:
+    - spec.tags.1.from.name
+
 # Labels to add to all resources and selectors.
 labels:
 - includeSelectors: true

--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -1,10 +1,13 @@
 odh-kubeflow-trainer-controller-image=quay.io/opendatahub/trainer:odh-3.4.0
 odh-training-cuda128-torch29-py312-image=quay.io/opendatahub/odh-training-cuda128-torch29-py312@sha256:0be52d5775e95026c3899a208d9fbecb59489d48763664e842b92e66d3c112c8
 odh-training-rocm64-torch29-py312-image=quay.io/opendatahub/odh-training-rocm64-torch29-py312@sha256:80878d0d51fa6bc8957f669e7f3facac13669562d393a6bfc45ca8dff277c2fa
-odh-th06-cuda130-torch210-py312-image=quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
-odh-th06-rocm64-torch291-py312-image=quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
-odh-th06-cpu-torch210-py312-image=quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4
-odh-openmpi-cuda-image=quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-stable
+odh-th06-cuda130-torch210-py312-image=quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1
+odh-th06-rocm64-torch291-py312-image=quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.5-ea1
+odh-th06-cpu-torch210-py312-image=quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.5-ea1
+odh-openmpi-cuda-image=quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-3.5-ea1
 odh-training-universal-workbench-image-cuda-3-4=quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
 odh-training-universal-workbench-image-rocm-3-4=quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
 odh-training-universal-workbench-image-cpu-3-4=quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4
+odh-training-universal-workbench-image-cuda-3-5=quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1
+odh-training-universal-workbench-image-rocm-3-5=quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.5-ea1
+odh-training-universal-workbench-image-cpu-3-5=quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/openmpi_cuda.yaml
+++ b/manifests/rhoai/runtimes/openmpi_cuda.yaml
@@ -33,7 +33,7 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-stable
+                      image: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-3.5-ea1
                       resources:
                         limits:
                           nvidia.com/gpu: "1"
@@ -48,7 +48,7 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-stable
+                      image: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-3.5-ea1
                       command:
                         - /usr/local/bin/uid_entrypoint.sh
                         - /usr/sbin/sshd

--- a/manifests/rhoai/runtimes/torch_distributed.yaml
+++ b/manifests/rhoai/runtimes/torch_distributed.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/torch_distributed_cpu.yaml
+++ b/manifests/rhoai/runtimes/torch_distributed_cpu.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/torch_distributed_cpu_torch210_py312.yaml
+++ b/manifests/rhoai/runtimes/torch_distributed_cpu_torch210_py312.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/torch_distributed_cuda130_torch210_py312.yaml
+++ b/manifests/rhoai/runtimes/torch_distributed_cuda130_torch210_py312.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/torch_distributed_rocm.yaml
+++ b/manifests/rhoai/runtimes/torch_distributed_rocm.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/torch_distributed_rocm64_torch291_py312.yaml
+++ b/manifests/rhoai/runtimes/torch_distributed_rocm64_torch291_py312.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/training_hub.yaml
+++ b/manifests/rhoai/runtimes/training_hub.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/training_hub_cpu.yaml
+++ b/manifests/rhoai/runtimes/training_hub_cpu.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/training_hub_rocm.yaml
+++ b/manifests/rhoai/runtimes/training_hub_rocm.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/training_hub_th06_cpu_torch210_py312.yaml
+++ b/manifests/rhoai/runtimes/training_hub_th06_cpu_torch210_py312.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cpu-torch210-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/training_hub_th06_cuda130_torch210_py312.yaml
+++ b/manifests/rhoai/runtimes/training_hub_th06_cuda130_torch210_py312.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1

--- a/manifests/rhoai/runtimes/training_hub_th06_rocm64_torch291_py312.yaml
+++ b/manifests/rhoai/runtimes/training_hub_th06_rocm64_torch291_py312.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
+                      image: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.5-ea1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Updating runtimes and image streams to 3.5-ea1

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all training runtime container images and universal workbench images from version 3.4 to 3.5-ea1.
  * Updated variants available for CPU, CUDA, and ROCm GPU architectures.
  * Designated new version 3.5 images as the recommended defaults, with previous version 3.4 marked as not recommended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->