### PR TITLE
Update params.env for odh-3.5.0-ea1-test

### DIFF
--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -1,4 +1,4 @@
-odh-kubeflow-trainer-controller-image=quay.io/opendatahub/trainer:odh-3.5.0-ea1-test
+odh-kubeflow-trainer-controller-image=quay.io/opendatahub/trainer:odh-3.5-ea1
 odh-training-cuda128-torch29-py312-image=quay.io/opendatahub/odh-training-cuda128-torch29-py312@sha256:0be52d5775e95026c3899a208d9fbecb59489d48763664e842b92e66d3c112c8
 odh-training-rocm64-torch29-py312-image=quay.io/opendatahub/odh-training-rocm64-torch29-py312@sha256:80878d0d51fa6bc8957f669e7f3facac13669562d393a6bfc45ca8dff277c2fa
 odh-th06-cuda130-torch210-py312-image=quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1

--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -1,4 +1,4 @@
-odh-kubeflow-trainer-controller-image=quay.io/opendatahub/trainer:odh-3.4.0
+odh-kubeflow-trainer-controller-image=quay.io/opendatahub/trainer:odh-3.5.0-ea1-test
 odh-training-cuda128-torch29-py312-image=quay.io/opendatahub/odh-training-cuda128-torch29-py312@sha256:0be52d5775e95026c3899a208d9fbecb59489d48763664e842b92e66d3c112c8
 odh-training-rocm64-torch29-py312-image=quay.io/opendatahub/odh-training-rocm64-torch29-py312@sha256:80878d0d51fa6bc8957f669e7f3facac13669562d393a6bfc45ca8dff277c2fa
 odh-th06-cuda130-torch210-py312-image=quay.io/opendatahub/odh-th06-cuda130-torch210-py312:odh-3.5-ea1


### PR DESCRIPTION
********** Please note created this release for testing purpose only for odh-release skill ***********

Updates the image tag in params.env to quay.io/opendatahub/trainer:odh-3.5.0-ea1-test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kubeflow trainer controller component to version 3.5.0-ea1-test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->