### PR TITLE
feat(ci): add operator-chaos L1 shift-left validation

### DIFF
--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -1,0 +1,190 @@
+name: Operator Chaos
+
+on:
+  pull_request:
+    paths:
+      - "pkg/apis/trainer/v1alpha1/**"
+      - "pkg/controller/**"
+      - "pkg/runtime/**"
+      - "manifests/base/crds/**"
+      - "manifests/base/rbac/**"
+      - "manifests/base/webhook/**"
+      - "manifests/rhoai/**"
+      - "chaos/knowledge/**"
+      - ".github/workflows/operator-chaos.yml"
+
+env:
+  OPERATOR_CHAOS_VERSION: "9e6ac9668b9aaca2f0f2ddf169867862b7925b80"
+
+jobs:
+  operator-chaos:
+    name: Operator Chaos
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          # operator-chaos requires go >= 1.25; repo go.mod targets 1.24.
+          # Pin explicitly to avoid GOTOOLCHAIN auto-download in CI.
+          go-version: "1.25"
+
+      - name: Install operator-chaos
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          GOBIN="${RUNNER_TEMP}/bin" go install "github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@${OPERATOR_CHAOS_VERSION}"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Verify operator-chaos binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v operator-chaos &>/dev/null; then
+            echo "operator-chaos binary not found in PATH after install."
+            exit 1
+          fi
+          operator-chaos version
+
+      - name: Checkout base branch assets
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-branch
+          persist-credentials: false
+          sparse-checkout: |
+            chaos/knowledge
+            manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+            manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
+            manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
+          sparse-checkout-cone-mode: false
+
+      - name: Reject symlinks in base-branch inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          symlinks=$(find base-branch/chaos/knowledge base-branch/manifests/base/crds \
+            -type l 2>/dev/null || true)
+          if [[ -n "${symlinks}" ]]; then
+            echo "Symlinks detected in base-branch checkout — aborting to prevent path traversal:"
+            echo "${symlinks}"
+            exit 1
+          fi
+
+      - name: Validate knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos validate --knowledge "chaos/knowledge/trainer.yaml"
+
+      - name: Run local preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos preflight --knowledge "chaos/knowledge/trainer.yaml" --local
+
+      - name: Diff knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge_file="base-branch/chaos/knowledge/trainer.yaml"
+          if [[ ! -f "${base_knowledge_file}" ]]; then
+            echo "No base knowledge model found; skipping knowledge diff for bootstrap PR."
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          knowledge_diff_json="${output_dir}/knowledge-diff.json"
+
+          operator-chaos diff \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --breaking \
+            --format json > "${knowledge_diff_json}"
+          operator-chaos diff \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --breaking
+
+          knowledge_breaking=$(jq -r '.summary.breakingChanges // 0' "${knowledge_diff_json}")
+          if (( knowledge_breaking > 0 )); then
+            echo "operator-chaos detected ${knowledge_breaking} breaking knowledge change(s)."
+            exit 1
+          fi
+
+      - name: Diff CRD schemas
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          total_breaking=0
+
+          for crd_name in \
+            "trainer.kubeflow.org_trainjobs.yaml" \
+            "trainer.kubeflow.org_trainingruntimes.yaml" \
+            "trainer.kubeflow.org_clustertrainingruntimes.yaml"; do
+
+            source_crd="base-branch/manifests/base/crds/${crd_name}"
+            target_crd="manifests/base/crds/${crd_name}"
+
+            if [[ ! -f "${source_crd}" || ! -f "${target_crd}" ]]; then
+              echo "Skipping ${crd_name}: not present in base or PR branch (bootstrap PR)."
+              continue
+            fi
+
+            source_dir="${output_dir}/${crd_name}-source"
+            target_dir="${output_dir}/${crd_name}-target"
+            crd_diff_json="${output_dir}/${crd_name}-diff.json"
+            rm -rf "${source_dir}" "${target_dir}"
+            mkdir -p "${source_dir}" "${target_dir}"
+            cp "${source_crd}" "${source_dir}/"
+            cp "${target_crd}" "${target_dir}/"
+
+            operator-chaos diff-crds \
+              --source-crds "${source_dir}" \
+              --target-crds "${target_dir}" \
+              --format json > "${crd_diff_json}"
+            operator-chaos diff-crds \
+              --source-crds "${source_dir}" \
+              --target-crds "${target_dir}"
+
+            crd_breaking=$(jq -r '
+              reduce ((.crds // [])[]?.apiVersions[]?.schemaChanges[]?) as $change
+              (0; if ($change.severity | ascii_downcase) == "breaking" then . + 1 else . end)
+            ' "${crd_diff_json}")
+
+            if (( crd_breaking > 0 )); then
+              echo "operator-chaos detected ${crd_breaking} breaking schema change(s) in ${crd_name}."
+              total_breaking=$(( total_breaking + crd_breaking ))
+            fi
+          done
+
+          if (( total_breaking > 0 )); then
+            echo "Total breaking CRD schema changes across all 3 CRDs: ${total_breaking}"
+            exit 1
+          fi
+
+      - name: Preview upgrade simulation
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge_file="base-branch/chaos/knowledge/trainer.yaml"
+          if [[ ! -f "${base_knowledge_file}" ]]; then
+            echo "No base knowledge model found; skipping simulate-upgrade for bootstrap PR."
+            exit 0
+          fi
+
+          operator-chaos simulate-upgrade \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --dry-run

--- a/chaos/knowledge/trainer.yaml
+++ b/chaos/knowledge/trainer.yaml
@@ -46,28 +46,8 @@ components:
         name: kubeflow-trainer-config
         namespace: opendatahub
 
-      # Public ConfigMap advertises the trainer version to SDK clients.
-      - apiVersion: v1
-        kind: ConfigMap
-        name: kubeflow-trainer-public
-        namespace: opendatahub
-
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        name: kubeflow-trainer-public
-        namespace: opendatahub
-
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        name: kubeflow-trainer-public
-        namespace: opendatahub
-
       # Webhook configurations — same binary serves both controller and webhooks.
       # failurePolicy: Fail means any downtime here blocks TrainJob admission.
-      - apiVersion: admissionregistration.k8s.io/v1
-        kind: MutatingWebhookConfiguration
-        name: mutating-webhook-configuration
-
       - apiVersion: admissionregistration.k8s.io/v1
         kind: ValidatingWebhookConfiguration
         name: validating-webhook-configuration

--- a/chaos/knowledge/trainer.yaml
+++ b/chaos/knowledge/trainer.yaml
@@ -1,0 +1,111 @@
+operator:
+  name: kubeflow-trainer
+  namespace: opendatahub
+  repository: https://github.com/opendatahub-io/trainer
+
+components:
+  - name: kubeflow-trainer-controller-manager
+    controller: TrainJobReconciler
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: kubeflow-trainer-controller-manager
+        namespace: opendatahub
+        labels:
+          app.kubernetes.io/name: trainer
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/part-of: kubeflow
+        expectedSpec:
+          replicas: 1
+
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: kubeflow-trainer-controller-manager
+        namespace: opendatahub
+
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: kubeflow-trainer-controller-manager
+
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: kubeflow-trainer-controller-manager
+
+      - apiVersion: v1
+        kind: Service
+        name: kubeflow-trainer-controller-manager
+        namespace: opendatahub
+
+      - apiVersion: v1
+        kind: Secret
+        name: kubeflow-trainer-webhook-cert
+        namespace: opendatahub
+
+      - apiVersion: v1
+        kind: ConfigMap
+        name: kubeflow-trainer-config
+        namespace: opendatahub
+
+      # Public ConfigMap advertises the trainer version to SDK clients.
+      - apiVersion: v1
+        kind: ConfigMap
+        name: kubeflow-trainer-public
+        namespace: opendatahub
+
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: kubeflow-trainer-public
+        namespace: opendatahub
+
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: kubeflow-trainer-public
+        namespace: opendatahub
+
+      # Webhook configurations — same binary serves both controller and webhooks.
+      # failurePolicy: Fail means any downtime here blocks TrainJob admission.
+      - apiVersion: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        name: mutating-webhook-configuration
+
+      - apiVersion: admissionregistration.k8s.io/v1
+        kind: ValidatingWebhookConfiguration
+        name: validating-webhook-configuration
+
+      # Leader election lease — resourceName from controller_manager_config.yaml.
+      - apiVersion: coordination.k8s.io/v1
+        kind: Lease
+        name: trainer.kubeflow.org
+        namespace: opendatahub
+
+      # RHOAI/ODH: aggregated RBAC roles for OpenShift user access management.
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: training-edit
+
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: training-admin
+
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: training-view
+
+      # RHOAI/ODH: PodMonitor for Prometheus metrics scraping.
+      - apiVersion: monitoring.coreos.com/v1
+        kind: PodMonitor
+        name: kubeflow-trainer-controller-manager-metrics-monitor
+        namespace: opendatahub
+
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: kubeflow-trainer-controller-manager
+          namespace: opendatahub
+          conditionType: Available
+
+recovery:
+  reconcileTimeout: "300s"
+  maxReconcileCycles: 10


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Level 1 (L1) shift-left upgrade validation using `operator-chaos`. A new GitHub Actions workflow runs static checks on every PR that touches APIs, CRDs, RBAC, webhooks, or the operator knowledge model — catching breaking changes before they land.

Two files are introduced:
- `chaos/knowledge/trainer.yaml` — operator topology model describing the `kubeflow-trainer-controller-manager` component, its 17 managed resources (Deployment, RBAC, webhooks, leases, ODH-specific ClusterRoles and PodMonitor), and steady-state expectations. Targets the `opendatahub` namespace for ODH/RHOAI.
- `.github/workflows/operator-chaos.yml` — CI gate that runs `validate`, `preflight --local`, `diff --breaking`, `diff-crds`, and `simulate-upgrade --dry-run` on qualifying PRs. Fails fast on breaking schema or topology changes.

**Which issue(s) this PR fixes**:
Fixes [RHOAIENG-63099](https://redhat.atlassian.net/browse/RHOAIENG-63099)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to validate operator and configuration changes with automated chaos-engineering checks, preflight validations, schema diffs, and upgrade simulation previews.
  * Added a Kubeflow Trainer operator knowledge model configuration, including controller setup, RBAC roles, admission webhook validation, metrics monitoring, and steady-state/recovery verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->