### PR TITLE
docs: add AI scaffolding tier 2

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_FILE_PATHS\" | grep -q '\\.go$'; then gofmt -w $CLAUDE_FILE_PATHS; fi"
+          },
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_FILE_PATHS\" | grep -q '\\.py$'; then black --quiet $CLAUDE_FILE_PATHS 2>/dev/null; fi"
+          },
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_FILE_PATHS\" | grep -q '\\.rs$'; then cargo fmt --manifest-path pkg/data_cache/Cargo.toml 2>/dev/null; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/add-new-crd/SKILL.md
+++ b/.claude/skills/add-new-crd/SKILL.md
@@ -1,0 +1,125 @@
+# Adding a New CRD to Kubeflow Trainer
+
+## When to use
+
+Use this skill when adding a new Custom Resource Definition (CRD) to the Kubeflow Trainer project, following the same patterns as the existing TrainJob, TrainingRuntime, and ClusterTrainingRuntime CRDs.
+
+## Steps
+
+### 1. Define API types
+
+Create or extend type definitions in `pkg/apis/trainer/v1alpha1/`:
+
+- Add the new type in a `<resource>_types.go` file with proper kubebuilder markers:
+  ```go
+  // +genclient
+  // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+  // +kubebuilder:object:root=true
+  // +kubebuilder:subresource:status          // if the resource has a status subresource
+  // +kubebuilder:storageversion
+  // +kubebuilder:resource:scope=Cluster      // only for cluster-scoped resources
+  ```
+- Add a corresponding `<Resource>List` type with `+kubebuilder:object:root=true`
+- Define `<Resource>Spec` and `<Resource>Status` structs
+- Use `// +kubebuilder:validation:*` markers for field-level validation
+- Follow the immutability pattern: mark fields with `// IMMUTABLE` in comments and enforce in webhooks
+
+Reference files:
+- `pkg/apis/trainer/v1alpha1/trainjob_types.go` — namespaced CRD with status subresource
+- `pkg/apis/trainer/v1alpha1/trainingruntime_types.go` — both namespaced and cluster-scoped CRDs sharing a spec type
+
+### 2. Register the type with the scheme
+
+Update `pkg/apis/trainer/v1alpha1/groupversion_info.go`:
+- The existing `SchemeBuilder` auto-registers types annotated with `+kubebuilder:object:root=true`
+- Also register in `cmd/trainer-controller-manager/main.go` if the type belongs to a new API group
+
+### 3. Run code generation
+
+```bash
+make generate    # Generates deepcopy, defaults, OpenAPI, and client code
+make manifests   # Generates CRD YAML, RBAC roles, and webhook manifests
+```
+
+Generated files:
+- `pkg/apis/trainer/v1alpha1/zz_generated.deepcopy.go` — DeepCopyObject implementations
+- `pkg/apis/trainer/v1alpha1/zz_generated.defaults.go` — defaulting functions
+- `manifests/base/crds/trainer.kubeflow.org_<resource>.yaml` — CRD YAML
+- `manifests/base/rbac/role.yaml` — updated ClusterRole
+- `charts/kubeflow-trainer/crds/` — Helm chart CRD copy
+
+### 4. Add a webhook
+
+Create `pkg/webhooks/<resource>_webhook.go` following the existing pattern:
+
+```go
+type <Resource>Webhook struct {
+    runtimes map[string]runtime.Runtime  // if runtime-aware validation is needed
+}
+
+// +kubebuilder:webhook:path=/validate-...,mutating=false,failurePolicy=fail,...
+func (w *<Resource>Webhook) ValidateCreate(ctx, obj) (warnings, error)
+func (w *<Resource>Webhook) ValidateUpdate(ctx, oldObj, newObj) (warnings, error)
+func (w *<Resource>Webhook) ValidateDelete(ctx, obj) (warnings, error)
+```
+
+Register the webhook in `pkg/webhooks/setup.go` inside the `Setup()` function.
+
+Reference: `pkg/webhooks/trainjob_webhook.go`, `pkg/webhooks/trainingruntime_webhook.go`
+
+### 5. Add a controller
+
+Create `pkg/controller/<resource>_controller.go`:
+
+- Define a reconciler struct with `client.Client`, `APIReader`, and event recorder
+- Implement `Reconcile(ctx, req) (ctrl.Result, error)`
+- Add RBAC markers:
+  ```go
+  // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=<resource>,verbs=get;list;watch;update;patch
+  // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=<resource>/status,verbs=get;update;patch
+  // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=<resource>/finalizers,verbs=get;update;patch
+  ```
+- Implement `SetupWithManager(mgr)` with `ctrl.NewControllerManagedBy(mgr).For(&v1alpha1.<Resource>{}).Complete(r)`
+- Register in `pkg/controller/setup.go` inside `SetupControllers()`
+
+Reference: `pkg/controller/trainjob_controller.go` (main reconciler with runtime delegation)
+
+### 6. Add runtime integration (if applicable)
+
+If the new CRD participates in the runtime framework:
+
+- Register in `pkg/runtime/core/registry.go` — add to `SupportedRuntimes()`
+- Implement the `runtime.Runtime` interface in `pkg/runtime/core/`
+- Add framework plugins if needed in `pkg/runtime/framework/plugins/`
+
+### 7. Update Helm chart
+
+- Copy the CRD YAML to `charts/kubeflow-trainer/crds/`
+- Add any new RBAC rules to chart templates
+- Update `charts/kubeflow-trainer/values.yaml` if new config is needed
+
+### 8. Add tests
+
+- **Unit tests**: Add to `pkg/controller/` and `pkg/webhooks/` for the new controller/webhook logic
+- **Integration tests**: Add Ginkgo suites in `test/integration/` using envtest
+- **E2E tests**: Add scenarios in `test/e2e/` if end-to-end validation is needed
+
+Run tests:
+```bash
+make test               # Go unit tests
+make test-integration   # Integration tests with envtest
+make test-e2e           # End-to-end tests (requires cluster)
+```
+
+### 9. Update kustomize manifests
+
+- Add CRD to `manifests/base/crds/kustomization.yaml`
+- Update `manifests/base/rbac/` if RBAC was regenerated
+- Add webhook configuration to `manifests/base/webhook/`
+
+## Key patterns to follow
+
+- Use `client.Apply()` with `FieldOwner("trainer")` for server-side apply (see TrainJobReconciler)
+- Use the `resource-in-use` finalizer pattern to prevent deletion of resources that are referenced by other CRs
+- Use the watcher pattern (see TrainingRuntimeReconciler) to react to changes in dependent resources
+- Package-level markers go in `doc.go`: `+k8s:defaulter-gen=TypeMeta`, `+k8s:openapi-gen=true`, `+k8s:deepcopy-gen=package`

--- a/.claude/skills/add-python-sdk-model/SKILL.md
+++ b/.claude/skills/add-python-sdk-model/SKILL.md
@@ -1,0 +1,174 @@
+# Adding a New Model or Method to the Python SDK
+
+## When to use
+
+Use this skill when adding or updating Python SDK models (Pydantic types for Kubernetes resources) or adding new initializer providers for dataset/model downloading.
+
+The Python SDK has two distinct parts:
+1. **Auto-generated API models** (`api/python_api/`) — Pydantic models generated from the OpenAPI spec
+2. **Initializers** (`pkg/initializers/`) — hand-written dataset and model download providers
+
+## Part A: Updating auto-generated API models
+
+### When to do this
+
+After modifying Go API types in `pkg/apis/trainer/v1alpha1/`, the Python models must be regenerated to stay in sync.
+
+### Steps
+
+1. **Update the Go API types** in `pkg/apis/trainer/v1alpha1/` (add/modify fields, types, markers)
+
+2. **Regenerate the OpenAPI spec and Python models**:
+   ```bash
+   make generate
+   ```
+   This runs the full generation pipeline:
+   - `controller-gen` generates CRD manifests and OpenAPI schema
+   - `hack/update-codegen.sh` regenerates Go clients
+   - `hack/python-api/gen-api.sh` regenerates Python SDK models
+
+3. **What gets generated**:
+   - `api/openapi-spec/swagger.json` — updated OpenAPI spec
+   - `api/python_api/kubeflow_trainer_api/models/` — 372+ Pydantic V2 model files
+   - `api/python_api/kubeflow_trainer_api/__init__.py` — model index with version
+
+4. **Do NOT manually edit** files in `api/python_api/kubeflow_trainer_api/models/` — they are overwritten on every generation run
+
+### Generation config
+
+- Config file: `hack/python-api/swagger_config.json`
+- Generator: OpenAPI Generator v7.13.0 (runs in a container via Docker/Podman)
+- Target: Pydantic V2 models with Python 3.9+ compatibility
+
+### Model structure
+
+Each generated model follows this pattern:
+```python
+class TrainerKubeflowOrgV1alpha1TrainJobSpec(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, protected_namespaces=())
+
+    runtime_ref: RuntimeRef = Field(alias="runtimeRef")
+    trainer: Optional[Trainer] = None
+    # ...
+
+    def to_dict(self) -> Dict[str, Any]: ...
+    def from_dict(cls, obj: Dict[str, Any]) -> Self: ...
+```
+
+### Package metadata
+
+- Package name: `kubeflow_trainer_api`
+- Version: defined in `api/python_api/kubeflow_trainer_api/__init__.py`
+- Build system: hatchling (`pyproject.toml`)
+- Dependencies: `pydantic>=2.10.0`
+
+## Part B: Adding a new initializer provider
+
+### When to do this
+
+When adding support for a new storage backend (e.g., GCS, Azure Blob) or a new model/dataset source for the init containers.
+
+### Steps
+
+#### 1. Define the configuration dataclass
+
+Add a new dataclass in `pkg/initializers/types/types.py`:
+
+```python
+@dataclass
+class GCSDatasetInitializer:
+    storage_uri: str = ""
+    ignore_patterns: list = field(default_factory=list)
+    project_id: str = ""
+    credentials_json: str = ""
+```
+
+Field names are converted to UPPERCASE environment variables automatically by `get_config_from_env()`.
+
+#### 2. Implement the provider
+
+Create `pkg/initializers/dataset/<provider>.py` (or `model/<provider>.py`):
+
+```python
+from pkg.initializers.utils.utils import DatasetProvider, DATASET_PATH
+
+class GCSDatasetProvider(DatasetProvider):
+    def load_config(self):
+        self._config = get_config_from_env(GCSDatasetInitializer)
+
+    def download_dataset(self):
+        # Implement download logic
+        # Download to DATASET_PATH (/workspace/dataset)
+        pass
+```
+
+Follow the existing pattern in:
+- `pkg/initializers/dataset/huggingface.py` — HuggingFace provider
+- `pkg/initializers/dataset/s3.py` — S3 provider using OpenDAL
+- `pkg/initializers/model/huggingface.py` — model variant
+
+#### 3. Register the URI scheme
+
+Update `pkg/initializers/dataset/__main__.py` (or `model/__main__.py`) to handle the new scheme:
+
+```python
+match urlparse(storage_uri).scheme:
+    case "hf":
+        provider = HuggingFaceDatasetProvider()
+    case "s3":
+        provider = S3DatasetProvider()
+    case "gcs":                              # new scheme
+        provider = GCSDatasetProvider()
+    case _:
+        raise ValueError(f"Invalid scheme: ...")
+```
+
+The URI scheme constants are defined in `pkg/initializers/utils/utils.py`.
+
+#### 4. Add requirements
+
+If the new provider needs additional Python packages, add them to the appropriate requirements file:
+- Dataset: `cmd/initializers/dataset/requirements.txt`
+- Model: `cmd/initializers/model/requirements.txt`
+
+#### 5. Write tests
+
+Add unit tests in `pkg/initializers/dataset/<provider>_test.py`:
+
+```python
+import pytest
+from pkg.initializers.dataset.<provider> import GCSDatasetProvider
+
+class TestGCSDatasetProvider:
+    @pytest.mark.parametrize("test_name,config,expected", [...])
+    def test_load_config(self, test_name, config, expected):
+        # Test config loading from env vars
+        pass
+
+    def test_download_dataset(self):
+        # Test download logic with mocked client
+        pass
+```
+
+Follow the testing patterns in:
+- `pkg/initializers/dataset/huggingface_test.py`
+- `pkg/initializers/dataset/s3_test.py`
+- `pkg/initializers/utils/utils_test.py`
+
+Run tests:
+```bash
+make test-python              # Unit tests
+make test-python-integration  # Integration tests
+```
+
+#### 6. Update Go constants (if needed)
+
+If the new provider introduces new URI schemes or container names, update `pkg/constants/constants.go`.
+
+## Key patterns
+
+- **Provider pattern**: All providers inherit from `DatasetProvider` or `ModelProvider` abstract base classes
+- **Config from env**: `get_config_from_env()` reflectively maps dataclass fields to env vars
+- **URI scheme dispatch**: Python 3.10+ `match/case` on `urlparse(storage_uri).scheme`
+- **Workspace paths**: Downloads go to `/workspace/dataset` or `/workspace/model`
+- **No manual model edits**: The `api/python_api/kubeflow_trainer_api/models/` directory is fully generated

--- a/.claude/skills/add-training-runtime/SKILL.md
+++ b/.claude/skills/add-training-runtime/SKILL.md
@@ -1,0 +1,177 @@
+# Adding a New TrainingRuntime or ClusterTrainingRuntime
+
+## When to use
+
+Use this skill when adding a new pre-built TrainingRuntime or ClusterTrainingRuntime manifest that defines a reusable training configuration (e.g., a new distributed framework, a new model fine-tuning recipe, or a new hardware-optimized setup).
+
+## Background
+
+TrainingRuntimes are templates that platform engineers create for data scientists. A TrainJob references a runtime via `runtimeRef`, and the controller merges the runtime's JobSet template with the TrainJob's overrides to produce the final workload.
+
+- **TrainingRuntime** — namespaced, available only within one namespace
+- **ClusterTrainingRuntime** — cluster-scoped, available to all namespaces (most common for pre-built runtimes)
+
+## Steps
+
+### 1. Understand the runtime spec structure
+
+A runtime spec has three top-level sections:
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime    # or TrainingRuntime
+metadata:
+  name: <runtime-name>
+spec:
+  mlPolicy:                     # ML framework config (optional)
+    numNodes: 1
+    torch:                      # OR mpi: (mutually exclusive)
+      numProcPerNode: auto
+  podGroupPolicy:               # Gang scheduling (optional)
+    coscheduling:
+      scheduleTimeoutSeconds: 60
+  template:                     # JobSet template (required)
+    spec:
+      replicatedJobs:
+        - name: <job-name>
+          template:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: trainer
+                      image: <image>
+                      ...
+```
+
+### 2. Choose the right ML policy
+
+**Torch (PyTorch distributed)**:
+```yaml
+mlPolicy:
+  numNodes: 1
+  torch:
+    numProcPerNode: auto   # "auto", "cpu", "gpu", or integer
+    # elasticPolicy:       # optional, for elastic training
+    #   minNodes: 1
+    #   maxNodes: 4
+```
+
+**MPI (Horovod, DeepSpeed with MPI)**:
+```yaml
+mlPolicy:
+  numNodes: 1
+  mpi:
+    numProcPerNode: 1
+    mpiImplementation: OpenMPI
+    runLauncherAsNode: false
+```
+
+**No policy** — for plain ML workloads without distributed training.
+
+### 3. Define the JobSet template
+
+The `template.spec` follows the [JobSet API](https://jobset.sigs.k8s.io/). Key fields:
+
+- `replicatedJobs[].name` — use ancestor labels to identify special roles:
+  - Label `trainer.kubeflow.org/trainjob-ancestor-step: trainer` on the main training job
+  - Label `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer` on dataset init jobs
+  - Label `trainer.kubeflow.org/trainjob-ancestor-step: model-initializer` on model init jobs
+
+- Container names matter:
+  - `node` — the main trainer container (required in jobs with the `trainer` ancestor)
+  - `dataset-initializer` — required in jobs with the `dataset-initializer` ancestor
+  - `model-initializer` — required in jobs with the `model-initializer` ancestor
+
+- Jobs with ancestor labels must have `replicas: 1`
+
+### 4. Create the manifest file
+
+Place the manifest in the appropriate location:
+
+- **Pre-built runtimes**: `manifests/base/runtimes/`
+  - General runtimes: `manifests/base/runtimes/<name>.yaml`
+  - TorchTune fine-tuning: `manifests/base/runtimes/torchtune/<model>/<variant>.yaml`
+  - Data-cache enabled: `manifests/base/runtimes/data-cache/`
+
+Reference existing runtimes:
+- `manifests/base/runtimes/torch_distributed.yaml` — basic PyTorch distributed
+- `manifests/base/runtimes/deepspeed_distributed.yaml` — DeepSpeed with MPI
+- `manifests/base/runtimes/mlx_distributed.yaml` — Apple MLX
+- `manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml` — TorchTune fine-tuning
+
+### 5. Register in kustomization
+
+Add the new manifest to `manifests/base/runtimes/kustomization.yaml`:
+```yaml
+resources:
+  - <your-new-runtime>.yaml
+```
+
+### 6. Add to RHOAI overlay (if applicable)
+
+For RHOAI-specific runtimes, also add to `manifests/rhoai/runtimes/`:
+- Create the runtime YAML there
+- Update `manifests/rhoai/runtimes/kustomization.yaml`
+
+### 7. Add framework plugin support (if new framework)
+
+If the runtime uses a new ML framework not yet supported:
+
+1. Create a new plugin in `pkg/runtime/framework/plugins/<framework>/`
+2. Implement the required plugin interfaces (see `pkg/runtime/framework/interface.go`):
+   - `EnforceMLPolicyPlugin` — to inject framework-specific env vars and config
+   - `CustomValidationPlugin` — to validate framework-specific fields
+   - `ComponentBuilderPlugin` — if the framework needs extra K8s resources (e.g., MPI needs SSH secrets)
+3. Register the plugin in `pkg/runtime/framework/plugins/registry.go`
+4. Add the framework's ML policy type to `pkg/apis/trainer/v1alpha1/trainingruntime_types.go`
+
+### 8. Validate
+
+- Ensure the runtime passes webhook validation:
+  - Jobs with ancestor labels have `replicas: 1`
+  - Required containers are present for each ancestor type
+  - Only one of `torch` or `mpi` is set in `mlPolicy`
+- Test with a TrainJob that references the new runtime
+- Run `make manifests` to regenerate if any Go types were changed
+
+### 9. Add Helm chart support (optional)
+
+If the runtime should be installable via Helm:
+- Add a template or static file in `charts/kubeflow-trainer/`
+- Consider making it toggleable via `values.yaml`
+
+## Example: minimal PyTorch distributed runtime
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: torch-distributed-custom
+spec:
+  mlPolicy:
+    numNodes: 1
+    torch:
+      numProcPerNode: auto
+  template:
+    spec:
+      replicatedJobs:
+        - name: trainer
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: docker.io/your-org/your-trainer:latest
+                      env:
+                        - name: TRAINING_SCRIPT
+                          value: train.py
+                      resources:
+                        requests:
+                          nvidia.com/gpu: "1"
+                  restartPolicy: OnFailure
+```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,255 @@
+# Architecture
+
+This document describes the architecture of the Kubeflow Trainer (V2) operator, the midstream fork maintained by the OpenDataHub / RHOAI team. The upstream source lives at [kubeflow/trainer](https://github.com/kubeflow/trainer); this repository (`opendatahub-io/trainer`) adds RHOAI-specific extensions.
+
+## High-level overview
+
+The operator manages three CRDs and produces [JobSet](https://jobset.sigs.k8s.io/) workloads. The key idea is a **separation of concerns**: data scientists define _what_ to train via a `TrainJob`, while platform engineers define _how_ to train via `TrainingRuntime` / `ClusterTrainingRuntime` templates.
+
+```
+TrainJob (user-facing)
+   │
+   │ runtimeRef
+   ▼
+TrainingRuntime / ClusterTrainingRuntime (platform-defined template)
+   │
+   │ controller + plugins
+   ▼
+JobSet → Jobs → Pods (actual workload)
+```
+
+## CRDs
+
+All three CRDs belong to the `trainer.kubeflow.org` API group, version `v1alpha1`.
+
+### TrainJob
+
+Namespaced resource. The data scientist's entry point. Key spec fields:
+
+| Field | Purpose |
+|---|---|
+| `runtimeRef` | References a TrainingRuntime (namespaced) or ClusterTrainingRuntime (cluster-scoped) by name and kind |
+| `trainer` | Overrides for the trainer container: image, command, args, env, numNodes, resourcesPerNode, numProcPerNode |
+| `initializer` | Optional dataset and model init containers with storage URIs and secrets |
+| `suspend` | Pause/resume the training job |
+| `managedBy` | Controller ownership — `trainer.kubeflow.org/trainjob-controller` (default) or `kueue.x-k8s.io/multikueue` |
+| `podTemplateOverrides` | Per-job overrides for pod spec (nodeSelector, tolerations, volumes, etc.) |
+
+Status tracks conditions (`Suspended`, `Complete`, `Failed`) and per-job status counts.
+
+Type definition: `pkg/apis/trainer/v1alpha1/trainjob_types.go`
+
+### TrainingRuntime
+
+Namespaced resource. Reusable training configuration template. Contains:
+
+- `mlPolicy` — ML framework config: `torch` (PyTorch distributed/elastic) or `mpi` (Horovod/DeepSpeed). Mutually exclusive.
+- `podGroupPolicy` — Gang scheduling via `coscheduling` (scheduler-plugins) or `volcano`.
+- `template` — A `JobSetSpec` defining the actual jobs and pods.
+
+Type definition: `pkg/apis/trainer/v1alpha1/trainingruntime_types.go`
+
+### ClusterTrainingRuntime
+
+Cluster-scoped version of TrainingRuntime. Shares the same `TrainingRuntimeSpec`. Can be referenced by TrainJobs in any namespace.
+
+## Controllers
+
+All three controllers live in `pkg/controller/` and are wired together in `pkg/controller/setup.go`.
+
+### TrainJobReconciler
+
+The main reconciler. On each reconciliation:
+
+1. Looks up the referenced runtime via the runtime registry
+2. Calls `runtime.NewObjects()` to generate Kubernetes ApplyConfigurations (JobSet + any framework-specific resources)
+3. Applies each object with server-side apply (`FieldOwner("trainer")`)
+4. Reconciles NetworkPolicy for pod network isolation (`pkg/rhai/networkpolicy.go`)
+5. Updates TrainJob status by delegating to `runtime.TrainJobStatus()`
+6. Runs RHOAI progression tracking if enabled via annotation
+7. Notifies runtime reconcilers of every create/update/delete event (watcher pattern)
+
+### TrainingRuntimeReconciler / ClusterTrainingRuntimeReconciler
+
+These reconcilers protect runtimes from deletion while in use. They:
+
+1. List all TrainJobs referencing the runtime
+2. Add a `resource-in-use` finalizer when TrainJobs reference the runtime
+3. Remove the finalizer when no TrainJobs reference it anymore
+
+They receive TrainJob lifecycle events from the TrainJobReconciler via the watcher pattern, triggering re-evaluation with a 1-second delay.
+
+## Runtime framework
+
+The runtime framework is a **plugin-based architecture** in `pkg/runtime/`.
+
+### Runtime interface
+
+```go
+type Runtime interface {
+    NewObjects(ctx, trainJob)           -> []ApplyConfiguration
+    RuntimeInfo(trainJob, template, …)  -> *Info
+    TrainJobStatus(ctx, trainJob)       -> *TrainJobStatus
+    EventHandlerRegistrars()            -> []ReconcilerBuilder
+    ValidateObjects(ctx, old, new)      -> (Warnings, ErrorList)
+}
+```
+
+### Runtime registry
+
+`pkg/runtime/core/registry.go` maps `apiGroup/kind` to runtime factories:
+
+| Key | Factory |
+|---|---|
+| `trainer.kubeflow.org/TrainingRuntime` | `NewTrainingRuntime` |
+| `trainer.kubeflow.org/ClusterTrainingRuntime` | `NewClusterTrainingRuntime` (wraps TrainingRuntime) |
+
+### Info struct
+
+`pkg/runtime/runtime.go` defines `Info` — an intermediate representation that plugins read and mutate. Contains extracted labels, annotations, ML/PodGroup policies, a JobSet apply-configuration template, and an abstract `PodSet` list (name, ancestor role, replica count, containers, resource requirements).
+
+### Plugin interfaces
+
+Defined in `pkg/runtime/framework/interface.go`:
+
+| Interface | Purpose |
+|---|---|
+| `EnforceMLPolicyPlugin` | Inject framework-specific env vars and config (e.g., TorchRun `PET_*` vars) |
+| `EnforcePodGroupPolicyPlugin` | Configure gang scheduling (coscheduling or volcano PodGroups) |
+| `CustomValidationPlugin` | Validate framework-specific constraints in webhooks |
+| `PodNetworkPlugin` | Identify pod network topology |
+| `ComponentBuilderPlugin` | Generate additional K8s resources (e.g., MPI SSH secrets, hostfile ConfigMaps) |
+| `TrainJobStatusPlugin` | Compute job status from child resources |
+| `WatchExtensionPlugin` | Register additional controller watches |
+
+### Built-in plugins
+
+Registered in `pkg/runtime/framework/plugins/registry.go`:
+
+| Plugin | Interfaces | Purpose |
+|---|---|---|
+| **Torch** | EnforceMLPolicy, CustomValidation | PyTorch distributed training — injects `PET_*` env vars, validates numProcPerNode, supports TorchTune |
+| **MPI** | EnforceMLPolicy, CustomValidation, ComponentBuilder, WatchExtension | MPI training — generates SSH key Secrets and hostfile ConfigMaps |
+| **PlainML** | EnforceMLPolicy | Fallback for non-distributed training |
+| **Coscheduling** | EnforcePodGroupPolicy | scheduler-plugins PodGroup creation |
+| **Volcano** | EnforcePodGroupPolicy | Volcano PodGroup creation |
+| **JobSet** | ComponentBuilder, TrainJobStatus | Builds the core JobSet resource and computes status from child Jobs |
+
+### Reconciliation flow
+
+```
+TrainJob created/updated
+  │
+  ▼
+TrainJobReconciler.Reconcile()
+  │
+  ├─ Look up Runtime from registry
+  │
+  ├─ runtime.NewObjects():
+  │    ├─ Fetch TrainingRuntime/ClusterTrainingRuntime from cluster
+  │    ├─ RuntimeInfo() → build Info struct
+  │    ├─ Run EnforceMLPolicy plugins → mutate Info
+  │    ├─ Run EnforcePodGroupPolicy plugins → mutate Info
+  │    ├─ Run PodNetwork plugins → mutate Info
+  │    ├─ Run ComponentBuilder plugins → generate ApplyConfigurations
+  │    └─ Return list of objects to apply
+  │
+  ├─ Server-side apply each object
+  ├─ Reconcile NetworkPolicy
+  ├─ Update status via runtime.TrainJobStatus()
+  └─ Run RHOAI progression tracking
+```
+
+## Webhooks
+
+Validating webhooks in `pkg/webhooks/`:
+
+- **TrainJob**: Validates that the referenced runtime exists; delegates to `runtime.ValidateObjects()` which runs all `CustomValidationPlugin`s
+- **TrainingRuntime / ClusterTrainingRuntime**: Validates JobSet template structure — jobs with ancestor labels must have `replicas: 1`, and must contain the required container name (`node`, `dataset-initializer`, or `model-initializer`)
+
+## Python initializers
+
+`pkg/initializers/` contains init-container implementations for downloading datasets and models before training starts.
+
+### Provider architecture
+
+```
+pkg/initializers/
+├── types/types.py          # Dataclass configs (one per provider × resource type)
+├── dataset/
+│   ├── __main__.py         # URI scheme → provider dispatch
+│   ├── huggingface.py      # hf:// scheme
+│   ├── s3.py               # s3:// scheme
+│   └── cache.py            # cache:// scheme (Ray-based distributed caching)
+├── model/
+│   ├── __main__.py         # URI scheme → provider dispatch
+│   ├── huggingface.py      # hf:// scheme
+│   └── s3.py               # s3:// scheme
+└── utils/
+    ├── utils.py            # Abstract base classes (DatasetProvider, ModelProvider)
+    └── opendal.py          # S3 abstraction via Apache OpenDAL
+```
+
+All providers implement `DatasetProvider` or `ModelProvider` (load config from env vars, download to `/workspace/dataset` or `/workspace/model`). URI scheme dispatch uses Python 3.10+ `match/case`.
+
+### Python API models
+
+`api/python_api/` contains auto-generated Pydantic V2 models for all Kubernetes types in the CRDs. Generated from `api/openapi-spec/swagger.json` via OpenAPI Generator. Do not edit manually — run `make generate` to regenerate.
+
+## Rust data cache
+
+`pkg/data_cache/` contains a distributed data caching service written in Rust:
+
+- **Head service** (`src/head/`) — coordinates workers, manages metadata, uses Apache Iceberg table format
+- **Worker service** (`src/worker/`) — stores and serves data partitions, uses Apache Arrow columnar format and DataFusion query engine
+- **Transport** — Arrow Flight (gRPC-based) for high-performance data transfer between nodes
+
+Built as two binaries (`head` and `worker`) from `pkg/data_cache/cmd/`. The `cache://` initializer scheme in the Python initializers creates a LeaderWorkerSet that runs these services.
+
+## RHOAI extensions
+
+`pkg/rhai/` contains midstream-specific features not present in upstream Kubeflow:
+
+- **Progression tracking** (`pkg/rhai/progression/`) — polls training metrics from pods and stores progress in TrainJob annotations. Enabled per-job via `trainer.opendatahub.io/progression-tracking: enabled`
+- **NetworkPolicy** (`pkg/rhai/networkpolicy.go`) — creates NetworkPolicy resources for pod network isolation during training
+- **RHOAI manifests** (`manifests/rhoai/`) — kustomize overlays with RHOAI-specific images, RBAC, and runtimes
+
+## Directory layout
+
+```
+cmd/
+├── trainer-controller-manager/   # Main Go binary — controller manager entrypoint
+├── data_cache/                   # Dockerfile for Rust data cache service
+├── initializers/                 # Dockerfile + requirements for Python init containers
+├── runtimes/                     # Container configs for DeepSpeed, MLX runtimes
+└── trainers/                     # Container configs for TorchTune trainers
+
+pkg/
+├── apis/
+│   ├── trainer/v1alpha1/         # CRD type definitions + generated code
+│   └── config/v1alpha1/          # Controller configuration types
+├── controller/                   # Kubernetes controllers (TrainJob, TrainingRuntime, ClusterTrainingRuntime)
+├── webhooks/                     # Validating webhooks
+├── runtime/
+│   ├── core/                     # Runtime registry and TrainingRuntime/ClusterTrainingRuntime implementations
+│   ├── framework/
+│   │   ├── core/                 # Plugin framework orchestration
+│   │   └── plugins/              # Built-in plugins (torch, mpi, plainml, jobset, coscheduling, volcano)
+│   └── indexer/                  # Field indexers for efficient TrainJob → Runtime lookups
+├── initializers/                 # Python init containers (dataset/model providers)
+├── data_cache/                   # Rust data cache service
+├── rhai/                         # RHOAI-specific extensions (progression, network policy)
+├── apply/                        # Server-side apply helpers
+├── client/                       # Generated Go client (informers, listers)
+├── config/                       # Controller configuration loading
+├── constants/                    # Shared constants (labels, env vars, paths)
+└── util/                         # Utilities (cert management, testing helpers)
+
+manifests/
+├── base/                         # Base kustomize manifests (CRDs, RBAC, webhook, runtimes)
+├── rhoai/                        # RHOAI-specific kustomize overlays
+└── third-party/                  # External dependencies
+
+charts/kubeflow-trainer/          # Helm chart (depends on jobset subchart)
+docs/proposals/                   # Design proposals (KEP-style)
+```


### PR DESCRIPTION
## Summary

- Add `.claude/skills/add-new-crd/SKILL.md` — guide for adding a new CRD (types, codegen, webhook, controller, runtime integration)
- Add `.claude/skills/add-training-runtime/SKILL.md` — guide for adding a new TrainingRuntime or ClusterTrainingRuntime
- Add `.claude/skills/add-python-sdk-model/SKILL.md` — guide for updating auto-generated API models and adding new initializer providers
- Add `.claude/settings.json` — PostToolUse hooks to auto-run `gofmt`, `black`, and `cargo fmt` after file edits
- Add `ARCHITECTURE.md` — documents controller architecture, CRD relationships, plugin framework, Python initializers, Rust data cache, and RHOAI extensions

Addresses AI Scaffolding Tier 2 checks (2.1, 2.2, 2.3) for the trainer repo.

## Test plan

- [ ] Validate `settings.json`: `python3 -m json.tool .claude/settings.json`
- [ ] Open a Claude Code session in the repo and confirm skills appear as `/add-new-crd`, `/add-training-runtime`, `/add-python-sdk-model`
- [ ] Edit a `.go` file and confirm `gofmt` hook runs automatically
- [ ] Edit a `.py` file and confirm `black` hook runs automatically
- [ ] Review `ARCHITECTURE.md` against `pkg/controller/`, `pkg/runtime/`, and `pkg/apis/` for accuracy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture and implementation guides covering the trainer operator, runtime setup, Python SDK extension, and CRD onboarding.
  * Included step-by-step documentation for adding new training runtimes and training-related resources.
* **Chores**
  * Added editor formatting hooks to automatically format files after tool usage across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->