### PR TITLE
CVE-2026-32283, CVE-2026-33814: bump go-toolset to 1.26

### DIFF
--- a/cmd/trainer-controller-manager/Dockerfile.odh
+++ b/cmd/trainer-controller-manager/Dockerfile.odh
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/trainer/v2
 
-go 1.25.0
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3
@@ -72,7 +72,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
 golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
## Summary
- Update builder image from `go-toolset:1.25` (Go 1.25.9) to `go-toolset:1.26` (Go 1.26.4)
- Fixes CVE-2026-32283 (crypto/tls DoS, CVSS 7.5) and CVE-2026-33814 (HTTP/2 DoS, CVSS 7.5)
- go-toolset:1.25 hasn't been updated since 2026-05-13; go-toolset:1.26 was updated 2026-07-07

## JIRA Tickets
- RHOAIENG-74659, RHOAIENG-74658 — CVE-2026-32283 odh-trainer-rhel9
- RHOAIENG-74210, RHOAIENG-74142 — CVE-2026-33814 odh-trainer-rhel9

## Test plan
- [x] Local build with go-toolset:1.26 succeeds
- [x] Binary compiled with Go 1.26.4 (verified via version stamp)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the trainer controller manager build environment to a newer Go toolchain.
  * Updated the project Go toolchain version and a related indirect networking dependency.
  * No changes were made to the application’s runtime behavior, entrypoint, or packaging steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->