### PR TITLE
feat: integrate with cluster TLS security profile

### DIFF
--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"net/http"
@@ -42,6 +43,7 @@ import (
 	"github.com/kubeflow/trainer/v2/pkg/controller"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	runtimecore "github.com/kubeflow/trainer/v2/pkg/runtime/core"
+	pkgtls "github.com/kubeflow/trainer/v2/pkg/tls"
 	"github.com/kubeflow/trainer/v2/pkg/util/cert"
 	"github.com/kubeflow/trainer/v2/pkg/webhooks"
 )
@@ -97,6 +99,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	restCfg := ctrl.GetConfigOrDie()
+
+	tlsResult, tlsErr := pkgtls.Resolve(context.Background(), restCfg)
+	if tlsErr != nil {
+		setupLog.Error(tlsErr, "Unable to resolve cluster TLS profile")
+		os.Exit(1)
+	}
+	options.Metrics.TLSOpts = append(options.Metrics.TLSOpts, tlsResult.TLSOpts...)
+
 	// Set client cache options
 	options.Client = client.Options{
 		Cache: &client.CacheOptions{
@@ -105,7 +116,7 @@ func main() {
 	}
 
 	setupLog.Info("Creating manager")
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
+	mgr, err := ctrl.NewManager(restCfg, options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -43,6 +43,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -91,6 +91,7 @@ func NewTrainJobReconciler(client client.Client, apiReader client.Reader, record
 	}
 }
 
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs/status,verbs=get;update;patch

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -1,0 +1,218 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var log = ctrl.Log.WithName("tls")
+
+var openSSLToGoCipher = map[string]uint16{
+	"TLS_AES_128_GCM_SHA256":               tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":               tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256":         tls.TLS_CHACHA20_POLY1305_SHA256,
+	"ECDHE-ECDSA-AES128-GCM-SHA256":        tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-RSA-AES128-GCM-SHA256":          tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-ECDSA-AES256-GCM-SHA384":        tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-RSA-AES256-GCM-SHA384":          tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-ECDSA-CHACHA20-POLY1305-SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305-SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-ECDSA-CHACHA20-POLY1305":        tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305":          tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+var intermediateCiphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+var tlsVersionMap = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+var apiServerGVR = schema.GroupVersionResource{
+	Group:    "config.openshift.io",
+	Version:  "v1",
+	Resource: "apiservers",
+}
+
+type tlsSecurityProfile struct {
+	Type   string `json:"type"`
+	Custom *struct {
+		Ciphers       []string `json:"ciphers"`
+		MinTLSVersion string   `json:"minTLSVersion"`
+	} `json:"custom,omitempty"`
+}
+
+// Result holds the resolved TLS configuration.
+type Result struct {
+	TLSOpts []func(*tls.Config)
+}
+
+// Resolve reads the cluster TLS profile from the APIServer resource using
+// dynamic client (no openshift/api dependency) and returns TLS option
+// functions for controller-runtime servers.
+// On clusters where the API is not available or temporarily unavailable,
+// it returns hardened Intermediate defaults.
+func Resolve(ctx context.Context, cfg *rest.Config) (Result, error) {
+	var result Result
+
+	resolveCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return result, fmt.Errorf("creating dynamic client for TLS profile: %w", err)
+	}
+
+	obj, err := dynClient.Resource(apiServerGVR).Get(resolveCtx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		switch {
+		case meta.IsNoMatchError(err):
+			log.Info("TLS profile API not available, using hardened defaults")
+		case apierrors.IsNotFound(err):
+			log.Info("APIServer resource not found, using hardened defaults")
+		case apierrors.IsServiceUnavailable(err),
+			apierrors.IsTimeout(err),
+			apierrors.IsTooManyRequests(err),
+			errors.Is(err, context.DeadlineExceeded):
+			log.Info("Transient API error reading TLS profile, using hardened defaults", "error", err)
+		default:
+			return result, fmt.Errorf("reading APIServer TLS profile: %w", err)
+		}
+		result.TLSOpts = append(result.TLSOpts, intermediateWithALPN)
+		return result, nil
+	}
+
+	profile, err := extractTLSProfile(obj)
+	if err != nil {
+		log.Info("Failed to parse TLS profile from APIServer, using hardened defaults", "error", err)
+		result.TLSOpts = append(result.TLSOpts, intermediateWithALPN)
+		return result, nil
+	}
+
+	minVersion, ciphers := parseProfile(profile)
+	if ciphers != nil && len(ciphers) == 0 {
+		return result, fmt.Errorf("custom TLS profile specified ciphers but none are supported by Go")
+	}
+
+	result.TLSOpts = append(result.TLSOpts, func(c *tls.Config) {
+		c.MinVersion = minVersion
+		if len(ciphers) > 0 {
+			c.CipherSuites = ciphers
+		}
+		c.NextProtos = []string{"h2", "http/1.1"}
+	})
+	return result, nil
+}
+
+func extractTLSProfile(obj *unstructured.Unstructured) (*tlsSecurityProfile, error) {
+	spec, ok := obj.Object["spec"].(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+	profileRaw, ok := spec["tlsSecurityProfile"]
+	if !ok || profileRaw == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(profileRaw)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling tlsSecurityProfile: %w", err)
+	}
+	var profile tlsSecurityProfile
+	if err := json.Unmarshal(data, &profile); err != nil {
+		return nil, fmt.Errorf("unmarshaling tlsSecurityProfile: %w", err)
+	}
+	return &profile, nil
+}
+
+func intermediateWithALPN(c *tls.Config) {
+	c.MinVersion = tls.VersionTLS12
+	c.CipherSuites = intermediateCiphers
+	c.NextProtos = []string{"h2", "http/1.1"}
+}
+
+func parseProfile(profile *tlsSecurityProfile) (uint16, []uint16) {
+	if profile == nil || profile.Type == "" {
+		return tls.VersionTLS12, intermediateCiphers
+	}
+
+	switch profile.Type {
+	case "Intermediate":
+		return tls.VersionTLS12, intermediateCiphers
+	case "Modern":
+		return tls.VersionTLS13, nil
+	case "Old":
+		return tls.VersionTLS10, nil
+	case "Custom":
+		if profile.Custom == nil {
+			log.Info("Custom TLS profile type specified but custom block is nil, falling back to Intermediate")
+			return tls.VersionTLS12, intermediateCiphers
+		}
+		return parseCustomProfile(profile.Custom)
+	default:
+		log.Info("Unknown TLS profile type, falling back to Intermediate", "type", profile.Type)
+		return tls.VersionTLS12, intermediateCiphers
+	}
+}
+
+func parseCustomProfile(custom *struct {
+	Ciphers       []string `json:"ciphers"`
+	MinTLSVersion string   `json:"minTLSVersion"`
+}) (uint16, []uint16) {
+	minVersion, ok := tlsVersionMap[custom.MinTLSVersion]
+	if !ok {
+		log.Info("Unknown minTLSVersion in custom profile, defaulting to TLS 1.2", "minTLSVersion", custom.MinTLSVersion)
+		minVersion = tls.VersionTLS12
+	}
+
+	if len(custom.Ciphers) == 0 {
+		return minVersion, nil
+	}
+
+	ciphers := make([]uint16, 0, len(custom.Ciphers))
+	for _, name := range custom.Ciphers {
+		if id, ok := openSSLToGoCipher[name]; ok {
+			ciphers = append(ciphers, id)
+		} else {
+			log.Info("Dropping unsupported cipher from custom TLS profile", "cipher", name)
+		}
+	}
+	return minVersion, ciphers
+}


### PR DESCRIPTION
## Description

Integrate the trainer controller with the cluster-wide TLS security profile from `apiservers.config.openshift.io/cluster`.

New `pkg/tls/` package reads the APIServer CR via dynamic client (no `openshift/api` dependency) and applies MinVersion, CipherSuites, and NextProtos to the metrics server TLS config. Falls back to Intermediate defaults (TLS 1.2, ECDHE ciphers, ALPN h2/http1.1) on non-OpenShift clusters or transient API errors.

Handles `context.DeadlineExceeded` alongside k8s API transient errors to prevent crash loops on slow API servers.

The `pkg/tls/` package is self-contained and designed to minimize conflicts with the upcoming upstream sync (kubeflow/trainer#3339 TLSOptions config + kubeflow/trainer#3594 CLI flags).

### Changes
- New `pkg/tls/tls.go`: cluster TLS profile resolution via dynamic client
- `cmd/trainer-controller-manager/main.go`: resolve TLS profile at startup, append to metrics server TLSOpts
- RBAC: `get` on `config.openshift.io/apiservers`
- Generated `manifests/base/rbac/role.yaml` updated

[RHOAIENG-67675](https://redhat.atlassian.net/browse/RHOAIENG-67675)

## How Has This Been Tested?

- `go build ./...` passes
- Pattern validated across 10+ other RHOAI repos with the same integration

[RHOAIENG-67675]: https://redhat.atlassian.net/browse/RHOAIENG-67675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of the cluster API server TLS security profile and conversion into controller-manager TLS settings.
  * Applied the resolved TLS options to controller-manager metrics, including support for custom profiles with hardened defaults.
* **Bug Fixes**
  * Extended RBAC permissions to allow reading API server TLS configuration.
  * Improved startup behavior by resolving TLS configuration before manager initialization and failing fast if resolution does not succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->