### PR TITLE
fix: set GOTOOLCHAIN=auto for CI compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ TRAINER_CHART_DIR := $(PROJECT_DIR)/charts/kubeflow-trainer
 # Location to install tool binaries
 LOCALBIN ?= $(PROJECT_DIR)/bin
 
+# Ensure Go auto-downloads the toolchain version required by go.mod
+export GOTOOLCHAIN := auto
+
 # Tool versions
 K8S_VERSION ?= 1.34.0
 GINKGO_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)


### PR DESCRIPTION
## Description

The CI e2e test pipeline fails because the runner has Go 1.25.7 with `GOTOOLCHAIN=local`, but `go.mod` requires Go 1.26.4 (bumped in 2dbc169d). The Makefile uses `$(shell go list -m ...)` to resolve tool versions, which fails before any tests can run.

### Fix

Set `GOTOOLCHAIN=auto` in the Makefile so Go auto-downloads the correct toolchain version as specified in `go.mod`. This is the standard Go mechanism for handling toolchain version requirements.

### Error before fix

```
go: go.mod requires go >= 1.26.4 (running go 1.25.7; GOTOOLCHAIN=local)
make: *** [Makefile:67: ginkgo] Error 1
```

### Changes

- Add `export GOTOOLCHAIN ?= auto` to the Makefile (1 line)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved setup reliability by enabling automatic selection and download of the required Go toolchain version when running Go-related commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->