### PR TITLE
fix: apply TLS profile to webhook server, remove enableHTTP2 flag

### DIFF
--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -33,6 +33,7 @@ import (
 	ctrlpkg "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	schedulerpluginsv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -68,20 +69,11 @@ func init() {
 
 func main() {
 	var configFile string
-	var enableHTTP2 bool
 
 	flag.StringVar(&configFile, "config", "",
 		"The controller will load its initial configuration from this file. "+
 			"Omit this flag to use the default configuration values. "+
 			"Command-line flags override configuration from this file.")
-	// if the enable-http2 flag is false (the default), http/2 should be disabled
-	// due to its vulnerabilities. More specifically, disabling http/2 will
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	flag.BoolVar(&enableHTTP2, "enable-http2", false,
-		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 
 	zapOpts := zap.Options{
 		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
@@ -93,7 +85,7 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
 
 	setupLog.Info("Loading configuration", "configFile", configFile)
-	options, cfg, err := config.Load(scheme, configFile, enableHTTP2)
+	options, cfg, err := config.Load(scheme, configFile)
 	if err != nil {
 		setupLog.Error(err, "Unable to load configuration")
 		os.Exit(1)
@@ -107,6 +99,16 @@ func main() {
 		os.Exit(1)
 	}
 	options.Metrics.TLSOpts = append(options.Metrics.TLSOpts, tlsResult.TLSOpts...)
+	webhookOpts := webhook.Options{
+		TLSOpts: tlsResult.TLSOpts,
+	}
+	if cfg.Webhook.Port != nil {
+		webhookOpts.Port = int(*cfg.Webhook.Port)
+		if cfg.Webhook.Host != nil {
+			webhookOpts.Host = *cfg.Webhook.Host
+		}
+	}
+	options.WebhookServer = webhook.NewServer(webhookOpts)
 
 	// Set client cache options
 	options.Client = client.Options{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"crypto/tls"
 	"fmt"
 	"os"
 
@@ -48,29 +47,18 @@ func fromFile(path string, scheme *runtime.Scheme, cfg *configapi.Configuration)
 }
 
 // addTo applies the configuration to controller runtime Options.
-func addTo(o *ctrl.Options, cfg *configapi.Configuration, enableHTTP2 bool) {
-	// Set metrics server options
-	var tlsOpts []func(*tls.Config)
-	if !enableHTTP2 {
-		// Disable http/2 for security reasons (CVE-2023-44487, CVE-2023-39325)
-		tlsOpts = append(tlsOpts, func(c *tls.Config) {
-			c.NextProtos = []string{"http/1.1"}
-		})
-	}
-
+func addTo(o *ctrl.Options, cfg *configapi.Configuration) {
 	o.Metrics = metricsserver.Options{
 		BindAddress:   cfg.Metrics.BindAddress,
 		SecureServing: cfg.Metrics.SecureServing != nil && *cfg.Metrics.SecureServing,
-		TLSOpts:       tlsOpts,
 	}
 
-	// Set webhook server options
 	if cfg.Webhook.Port != nil {
-		o.WebhookServer = webhook.NewServer(webhook.Options{
-			Port:    int(*cfg.Webhook.Port),
-			Host:    *cfg.Webhook.Host,
-			TLSOpts: tlsOpts,
-		})
+		webhookOpts := webhook.Options{Port: int(*cfg.Webhook.Port)}
+		if cfg.Webhook.Host != nil {
+			webhookOpts.Host = *cfg.Webhook.Host
+		}
+		o.WebhookServer = webhook.NewServer(webhookOpts)
 	}
 
 	// Set health probe bind address
@@ -102,7 +90,7 @@ func addTo(o *ctrl.Options, cfg *configapi.Configuration, enableHTTP2 bool) {
 
 // Load loads configuration from file and returns controller Options and Configuration.
 // If configFile is empty, default configuration is used.
-func Load(scheme *runtime.Scheme, configFile string, enableHTTP2 bool) (ctrl.Options, configapi.Configuration, error) {
+func Load(scheme *runtime.Scheme, configFile string) (ctrl.Options, configapi.Configuration, error) {
 	options := ctrl.Options{
 		Scheme: scheme,
 	}
@@ -125,7 +113,7 @@ func Load(scheme *runtime.Scheme, configFile string, enableHTTP2 bool) (ctrl.Opt
 	}
 
 	// Apply configuration to options
-	addTo(&options, &cfg, enableHTTP2)
+	addTo(&options, &cfg)
 
 	return options, cfg, nil
 }

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -110,6 +110,7 @@ func Resolve(ctx context.Context, cfg *rest.Config) (Result, error) {
 			log.Info("APIServer resource not found, using hardened defaults")
 		case apierrors.IsServiceUnavailable(err),
 			apierrors.IsTimeout(err),
+			apierrors.IsServerTimeout(err),
 			apierrors.IsTooManyRequests(err),
 			errors.Is(err, context.DeadlineExceeded):
 			log.Info("Transient API error reading TLS profile, using hardened defaults", "error", err)


### PR DESCRIPTION
## Description

Follow-up to #187. Fixes three issues:

1. **Webhook TLSOpts missing**: the TLS profile was only applied to the metrics server, the webhook server was using default TLS settings.
2. **enableHTTP2 flag removal**: the `--enable-http2` flag disabled HTTP/2 as a mitigation for CVE-2023-44487 (Rapid Reset), but that CVE was fixed in Go 1.21.3 and this repo runs Go 1.26.4. The TLS profile resolver sets ALPN to `["h2", "http/1.1"]` which is the correct post-fix behavior. No deployment manifests pass the flag.
3. **IsServerTimeout handling**: `apierrors.IsServerTimeout` was missing from transient error handling in TLS profile resolution.

### Changes

- `cmd/trainer-controller-manager/main.go`: apply TLSOpts to webhook server preserving port/host from config, remove `--enable-http2` flag and variable
- `pkg/config/config.go`: remove `enableHTTP2` parameter from `Load`/`addTo`, remove HTTP/2 disabling TLSOpts logic, remove `crypto/tls` import
- `pkg/tls/tls.go`: add `apierrors.IsServerTimeout` to transient error handling

RHOAIENG-67675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified controller startup configuration by removing the HTTP/2 setting.
  * Webhook server host and port settings are now applied consistently when configured.
* **Bug Fixes**
  * Improved resilience when retrieving API server TLS settings by using secure fallback settings during temporary server timeouts.
  * Webhook TLS configuration is now applied more reliably during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->