### PR TITLE
fix: pass commit message via env var in lake-gate workflow

### DIFF
--- a/.github/workflows/sync-stream-to-lake.yml
+++ b/.github/workflows/sync-stream-to-lake.yml
@@ -115,6 +115,8 @@ jobs:
         if: steps.check_diff.outputs.has_diff == 'true' && (steps.check_pr.outputs.pr_exists == 'false' || steps.check_pr.outputs.pr_current == 'false')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST_COMMIT_SHORT: ${{ steps.check_diff.outputs.latest_commit_short }}
+          LATEST_COMMIT_MSG: ${{ steps.check_diff.outputs.latest_commit_msg }}
         run: |
           # Create timestamp-based branch name
           TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
@@ -125,10 +127,6 @@ jobs:
           # Create and push new branch from main
           git checkout -b "$BRANCH_NAME" origin/main
           git push origin "$BRANCH_NAME"
-
-          # Create PR with detailed description
-          LATEST_COMMIT_SHORT="${{ steps.check_diff.outputs.latest_commit_short }}"
-          LATEST_COMMIT_MSG="${{ steps.check_diff.outputs.latest_commit_msg }}"
 
           PR_BODY=$(cat <<EOF
           ## Sync Stream (main) to Lake (stable)


### PR DESCRIPTION
## Summary
- Fixes shell quoting bug in the `Sync Stream to Lake` workflow that caused `exit code 127`
- The `${{ }}` expression expanded the commit message as raw text into the shell script before bash ran — when the message contained double quotes (e.g. `"go list"` and `"go install"`), it broke the shell assignment and bash tried to execute fragments as commands
- Moves `LATEST_COMMIT_SHORT` and `LATEST_COMMIT_MSG` to the step's `env:` block so they are set as proper environment variables instead of inline string substitution

**Failed run:** https://github.com/opendatahub-io/trainer/actions/runs/29651613587/job/88098783060

## Test plan
- [ ] Re-run the `Sync Stream to Lake` workflow after merge
- [ ] Verify the lake-gate PR is created successfully even when the latest commit message contains special shell characters (quotes, backticks, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated synchronization pull request generation by passing commit details through the workflow environment.
  * Preserved existing branch and pull request creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->