### PR TITLE
fix: point trainer controller image at odh-3.5.0

### DIFF
--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -1,4 +1,4 @@
-odh-kubeflow-trainer-controller-image=quay.io/opendatahub/trainer:odh-3.5
+odh-kubeflow-trainer-controller-image=quay.io/opendatahub/trainer:odh-3.5.0
 odh-th-torch-cuda-py312-image=quay.io/opendatahub/odh-th-torch-cuda-py312:odh-3.5
 odh-th-torch-rocm-py312-image=quay.io/opendatahub/odh-th-torch-rocm-py312:odh-3.5
 odh-th-torch-cpu-py312-image=quay.io/opendatahub/odh-th-torch-cpu-py312:odh-3.5


### PR DESCRIPTION
Konflux release-push publishes quay.io/opendatahub/trainer:odh-3.5.0, but params.env referenced the non-existent odh-3.5 stream tag, causing operator RHOAI e2e ImagePullBackOff (RHOAIENG-80313). Leave TH image tags on odh-3.5 where those Quay tags already exist.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kubeflow Trainer controller to the `odh-3.5.0` image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->