### PR TITLE
bump controller manager image to v2.3.0

### DIFF
--- a/manifests/component_metadata.yaml
+++ b/manifests/component_metadata.yaml
@@ -1,4 +1,4 @@
 releases:
   - name: Kubeflow Trainer
-    version: "2.1.0"
+    version: "2.3.0"
     repoUrl: https://github.com/kubeflow/trainer

--- a/manifests/overlays/manager/kustomization.yaml
+++ b/manifests/overlays/manager/kustomization.yaml
@@ -42,6 +42,6 @@ secretGenerator:
 configMapGenerator:
   - name: kubeflow-trainer-public
     literals:
-      - kubeflow_trainer_version=v2.3.0
+      - kubeflow_trainer_version=dev
     options:
       disableNameSuffixHash: true

--- a/manifests/overlays/manager/kustomization.yaml
+++ b/manifests/overlays/manager/kustomization.yaml
@@ -29,7 +29,7 @@ resources:
 # Update the Kubeflow Trainer controller manager image tag.
 images:
   - name: ghcr.io/kubeflow/trainer/trainer-controller-manager
-    newTag: v2.1.0
+    newTag: v2.3.0
 
 # Secret for the Kubeflow Training webhook.
 secretGenerator:
@@ -42,6 +42,6 @@ secretGenerator:
 configMapGenerator:
   - name: kubeflow-trainer-public
     literals:
-      - kubeflow_trainer_version=dev
+      - kubeflow_trainer_version=v2.3.0
     options:
       disableNameSuffixHash: true


### PR DESCRIPTION
Manager overlay still pins trainer-controller-manager to v2.1.0 after the 2.3 merge. Kind E2E installs trainer@main and the controller never becomes Available.

Bump image tag and kubeflow_trainer_version to v2.3.0 to match upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Trainer controller manager to version **v2.3.0**.
  * Updated the public configuration version to align with the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->