### PR TITLE
Update image tags to 'odh-stable' version

### DIFF
--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -1,10 +1,10 @@
-odh-kubeflow-trainer-controller-image=quay.io/opendatahub/trainer:odh-3.5.0
-odh-th-torch-cuda-py312-image=quay.io/opendatahub/odh-th-torch-cuda-py312:odh-3.5
-odh-th-torch-rocm-py312-image=quay.io/opendatahub/odh-th-torch-rocm-py312:odh-3.5
-odh-th-torch-cpu-py312-image=quay.io/opendatahub/odh-th-torch-cpu-py312:odh-3.5
+odh-kubeflow-trainer-controller-image=quay.io/opendatahub/trainer:odh-stable
+odh-th-torch-cuda-py312-image=quay.io/opendatahub/odh-th-torch-cuda-py312:odh-stable
+odh-th-torch-rocm-py312-image=quay.io/opendatahub/odh-th-torch-rocm-py312:odh-stable
+odh-th-torch-cpu-py312-image=quay.io/opendatahub/odh-th-torch-cpu-py312:odh-stable
 odh-training-universal-workbench-image-cuda-3-4=quay.io/opendatahub/odh-th06-cuda130-torch291-py312:odh-3.4
 odh-training-universal-workbench-image-rocm-3-4=quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-3.4
 odh-training-universal-workbench-image-cpu-3-4=quay.io/opendatahub/odh-th06-cpu-torch291-py312:odh-3.4
-odh-training-universal-workbench-image-cuda-3-5=quay.io/opendatahub/odh-th-torch-cuda-py312:odh-3.5
-odh-training-universal-workbench-image-rocm-3-5=quay.io/opendatahub/odh-th-torch-rocm-py312:odh-3.5
-odh-training-universal-workbench-image-cpu-3-5=quay.io/opendatahub/odh-th-torch-cpu-py312:odh-3.5
+odh-training-universal-workbench-image-cuda-3-5=quay.io/opendatahub/odh-th-torch-cuda-py312:odh-stable
+odh-training-universal-workbench-image-rocm-3-5=quay.io/opendatahub/odh-th-torch-rocm-py312:odh-stable
+odh-training-universal-workbench-image-cpu-3-5=quay.io/opendatahub/odh-th-torch-cpu-py312:odh-stable


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated AI platform container images to use stable release references.
  * Applied stable references to trainer controller, CUDA, ROCm, CPU Torch, and 3.5 universal workbench images.
  * No changes were made to 3.4 workbench image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->